### PR TITLE
Adds basic GPIO, UART and SPI functionality, and W5100 SPI commands

### DIFF
--- a/core/Debug/debug.h
+++ b/core/Debug/debug.h
@@ -1,0 +1,18 @@
+/*
+ * debug.h
+ *
+ * Created: 12/7/2016 9:01:47 PM
+ *  Author: inselc
+ */ 
+
+
+#ifndef DEBUG_H_
+#define DEBUG_H_
+
+#include "../../core/Serial/Serial.h"
+
+#define DEBUG_LOG(x) serialWriteStr("\r\n -- DEBUG . "); \
+					 serialWriteStr(x); \
+					 serialWriteStr(" --\r\n")
+
+#endif /* DEBUG_H_ */

--- a/core/Serial/Serial.c
+++ b/core/Serial/Serial.c
@@ -1,0 +1,287 @@
+/*! @brief Serial communication over USART
+ *
+ *	@author	inselc
+ *	@date	05.12.16	initial version								*/ 
+
+/*! @file */
+
+#include "Serial.h"
+
+/*! @brief Push data into receive ring buffer
+ *
+ *	@param[in] data			Data to be pushed into the buffer
+ *	@return bool			false, if write failed (buffer full)
+ *	@date 07.12.16			first implementation					*/
+static bool serialPushRxBuf(uint8_t data)
+{
+	// Check buffer full
+	if (serialRxBuf.full)
+	{
+		return false;
+	}
+
+	// Clear buffer empty flag
+	serialRxBuf.empty = false;
+	
+	// Write data into buffer
+	serialRxBuf.data[serialRxBuf.head] = data;
+	
+	// Advance head pointer
+	serialRxBuf.head = (serialRxBuf.head + 1) % SERIAL_BUF_SIZE;
+
+	// Recalculate buffer full flag
+	if (serialRxBuf.head == serialRxBuf.tail)
+	{
+		serialRxBuf.full = true;
+	}
+
+	return true;
+}
+
+/*! @brief Pop data from receive ring buffer
+ *
+ *	@return uint8_t			Data at buffer tail. 0x00, if buffer empty
+ *	@date 07.12.16			first implementation					*/
+static uint8_t serialPopRxBuf(void)
+{
+	uint8_t data;
+	if (serialRxBuf.empty)
+	{
+		return 0x00;
+	}
+	else
+	{
+		// Clear buffer full flag
+		serialRxBuf.full = false;
+
+		// Read data from buffer
+		data = serialRxBuf.data[serialRxBuf.tail];
+
+		// Advance tail pointer
+		serialRxBuf.tail = (serialRxBuf.tail + 1) % SERIAL_BUF_SIZE;
+
+		// Check buffer empty
+		if (serialRxBuf.tail == serialRxBuf.head)
+		{
+			serialRxBuf.empty = true;
+		}
+
+		return data;
+	}
+}
+
+/*! @brief Read from serial into buffer, until ring buffer is empty
+ *
+ *	@param[out]	*buffer		Target buffer
+ *	@param[in] bufSize		Maximum buffer size
+ *	@param[in] timeout		Cycles until timeout (-1: infinite)
+ *	@return uint8_t			Number of bytes read
+ *	@date 07.12.16			first implementation					*/
+uint8_t serialReadBuf(uint8_t* buffer, uint8_t bufSize, int timeout)
+{
+	uint8_t byteCount = 0;
+	int timeoutCount = 0;
+
+	// catch Null-pointer exception 
+	if (buffer == NULL || bufSize == 0)
+		return 0x00;
+
+	// read until ring buffer is empty or target buffer is full
+	while (byteCount < bufSize && (timeoutCount < timeout || timeout < 0))
+	{
+		if (serialRxBuf.empty)
+		{
+			// Buffer is empty, wait for timeout
+			timeoutCount = (timeoutCount + 1) % INT_MAX;
+		}
+		else
+		{
+			// Buffer is not empty. Read data
+			buffer[byteCount] = serialPopRxBuf();
+			byteCount++;
+
+			// Reset timeout counter
+			timeoutCount = 0;
+		}
+	}
+
+	return byteCount;
+}
+
+/*! @brief Read from serial into buffer, until character found
+ *
+ * Will read until char is found or waiting on buffer empty times out,
+ * or target buffer is full.
+ *
+ *	@param[out] *buffer		Target buffer
+ *	@param[in] bufSize		Maximum buffer size
+ *	@param[in] stopChar		Key char to stop read
+ *	@param[in] timeout		Cycles until timeout (-1: infinite)
+ *	@return uint8_t			Number of bytes read
+ *	@date 07.12.16			first implementation					*/
+uint8_t serialReadBufUntil(uint8_t* buffer, uint8_t bufSize, char stopChar, int timeout)
+{
+	uint8_t byteCounter = 0;
+	int timeoutCount = 0;
+	
+	// Null pointer exception 
+	if (buffer == NULL || bufSize == 0)
+		return 0x00;
+
+	while(byteCounter < bufSize && (timeoutCount < timeout || timeout < 0))
+	{
+		if (serialRxBuf.empty)
+		{
+				timeoutCount = (timeoutCount + 1) % INT_MAX;
+		}
+		else
+		{
+			buffer[byteCounter] = serialPopRxBuf();
+			timeoutCount = 0;
+			byteCounter++;
+			
+			if (buffer[byteCounter-1] == (uint8_t)stopChar)
+			{
+				// success, found stop char
+				return byteCounter;
+			}
+		}
+	}
+
+	// fail: buffer overflow or timeout
+	return byteCounter;
+}
+
+/*! @brief Get next byte from receive ring buffer, without removing it
+ *
+ *	@return uint8_t			Next byte in ring buffer (from tail). 0x00, if empty.
+ *	@date 07.12.16			first implementation					*/
+uint8_t serialPeek(void)
+{
+	if (!serialRxBuf.empty)
+	{
+		return serialRxBuf.data[serialRxBuf.tail];
+	}
+	else
+	{
+		return 0x00;
+	}
+}
+
+/*! @brief Get number of available bytes in ring buffer
+ *
+ *  @return uint8_t			Number of unread bytes
+ *	@date 07.12.16			first implementation					*/
+uint8_t serialAvailable(void)
+{
+	return ((serialRxBuf.head + SERIAL_BUF_SIZE - serialRxBuf.tail) % SERIAL_BUF_SIZE);
+}
+
+/*! @brief Read single byte from RX ring buffer
+ *
+ *	@return	uint8_t			Byte from ring buffer, 0x00 if empty
+ *	@date 07.12.16			first implementation					*/
+uint8_t serialRead(void)
+{
+	return serialPopRxBuf();
+}
+
+/*! @brief Output string via serial connection (USART RS232)
+ *
+ * This method will only work, if USART is configured for a
+ * character length of 8+ bits!
+ *
+ *	@param[in] *message			String to be transmitted (\0-term.!)
+ *	@return int					Number of characters sent
+ *	@date 05.12.16				first implementation				*/
+int serialWriteStr(const char* message)
+{
+	int stringPos = 0;
+
+	// Catch null-pointer exception
+	if (message == NULL)
+	{
+		return -1;
+	}
+
+	// Transmit message, including trailing \0
+	// Abort, if maximum string length exceeded
+	while ((message[stringPos] != '\0') && (stringPos < SERIAL_MAX_STRLEN))
+	{
+		usartWaitDREmpty();
+		usartSendData(message[stringPos]);
+		stringPos++;
+	}
+
+	return stringPos;
+}
+
+/*! @brief Output String from FLASH via Serial
+ *
+ *	@warn Not yet implemented
+ *
+ *	@param[in] *message			String to be transmitted (\0-Term!)
+ *	@return int					Number of chars sent
+ *	@date 13.12.16				first implementation				*/
+int serialWriteStrP(const PROGMEM char* message)
+{
+	return 0;
+}
+
+/*! @brief Output via serial from non-progmem memory buffer
+ *
+ * This method will ignore the buffer content, and output until
+ * configured byte count is transmitted.
+ *
+ *	@param[in] *data			Source buffer to transmit from
+ *	@param[in] count			Number of bytes to transmit
+ *	@param[in] timeout			Cycles until write times out (-1=inf)
+ *	@return uint16_t			Number of bytes actually transmitted
+ *	@date 07.12.16				first implementation				*/
+uint16_t serialWriteBuf(uint8_t* data, uint16_t count, int timeout)
+{
+	int byteCounter = 0;
+	int timeoutCount = 0;
+
+	// Null-pointer exception
+	if (data == NULL)
+		return 0;
+
+	while (byteCounter < count && (timeoutCount < timeout || timeout < 0))
+	{
+		if (usartUDRE())
+		{
+			usartSendData(data[byteCounter]);
+			byteCounter++;
+		}
+		else
+		{
+			timeoutCount = (timeoutCount + 1) % INT_MAX;
+		}
+	}
+
+	return byteCounter;
+}
+
+/*! @brief Discard remaining data in receive ring buffer
+ *
+ *	@date 07.12.16				first implementation				*/
+void serialFlush(void)
+{
+	serialRxBuf.head = 0;
+	serialRxBuf.tail = 0;
+	serialRxBuf.empty = true;
+	serialRxBuf.full = false;
+}
+
+// -----------------------------------------------------------------
+
+/*! @brief USART Receive ISR: read data into ring buffer
+ *
+ *	@date 07.12.16				first implementation				*/
+ISR(USART_RX_vect)
+{
+	// copy data from USART buffer into ring buffer
+	// this read from UDR will automatically clear the RXC flag
+	serialPushRxBuf(usartReadData());
+}

--- a/core/Serial/Serial.h
+++ b/core/Serial/Serial.h
@@ -1,0 +1,78 @@
+/*! @brief Serial communication over USART
+ *
+ *	@author	inselc
+ *	@date	05.12.16	initial version								*/ 
+
+#ifndef SERIAL_H_
+#define SERIAL_H_
+
+/*! @file */
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <limits.h>
+#include <avr/pgmspace.h>
+#include <avr/interrupt.h>
+
+#include "../../modules/usart/usart_common.h"
+#include "../../modules/usart/usart_rs232.h"
+
+#define SERIAL_MAX_STRLEN	64		/* maximum string length for tx	*/
+#define SERIAL_BUF_SIZE		64		/* receive ringbuffer size		*/
+
+/*! @struct serialRingBuffer_t
+ *	USART Receive data ring buffer
+ *	@var serialRingBuffer_t::head
+ *	Ring buffer head index
+ *	@var serialRingBuffer_t::tail
+ *	Ring buffer tail index
+ *	@var serialRingBuffer_t::empty
+ *	Ring buffer EMPTY flag
+ *	@var serialRingBuffer_t::full
+ *	Ring buffer FULL flag
+ *  @var serialRingBuffer_t::data
+ *	Data array														*/
+typedef volatile struct tagSerialRingBuffer_t
+{
+	uint8_t head;
+	uint8_t tail;
+	bool empty;
+	bool full;
+	uint8_t data[SERIAL_BUF_SIZE];
+} serialRingBuffer_t;
+
+static serialRingBuffer_t serialRxBuf;
+
+/* Prototypes */
+uint8_t serialAvailable(void);
+uint8_t serialReadBuf(uint8_t* buffer, uint8_t bufSize, int timeout);
+uint8_t serialReadBufUntil(uint8_t* buffer, uint8_t bufSize, char stopChar, int timeout);
+uint8_t serialRead(void);
+uint8_t serialPeek(void);
+int serialWriteStr(const char* message);
+int serialWriteStrP(const PROGMEM char* message);
+uint16_t serialWriteBuf(uint8_t* data, uint16_t length, int timeout);
+void serialFlush(void);
+
+/*! @brief Transmit single byte via serial
+ *
+ *	@param[in] data			Byte to be transmitted
+ *	@date 07.12.16			first implementation					*/
+inline void serialWrite(uint8_t data)
+{
+	usartSendData(data);
+}
+
+/*! @brief Quick-Init for Serial over USART in RS232 mode
+ *
+ *	@note requires interrupts to be enabled.
+ *
+ *	@param[in] baudrate		USART Baudrate
+ *	@date 07.12.16			first implementation					*/
+inline void serialInit(usartBaudrate_t baudrate)
+{
+	serialFlush();
+	usartInitRs232(USART_MSTR_ASYNC, baudrate, USART_LEN_8, USART_PARITY_NONE, USART_SBIT_1);
+}
+#endif /* SERIAL_H_ */

--- a/drivers/W5100/W5100.c
+++ b/drivers/W5100/W5100.c
@@ -1,0 +1,103 @@
+/*! @brief Wiznet W5100 Ethernet Controller driver
+ *
+ *	@author	inselc
+ *	@date	10.12.16		initial version							*/ 
+
+#include "W5100.h"
+#include "../../modules/spi/spi.h"
+#include "../../modules/io/io.h"
+
+// ChipSelect pin the W5100 is connected to
+// Arduino 10 = PB2
+static pin_t csPinW5100 = {
+	.Port	= &PORTB,
+	.DDR = &DDRB,
+	.PINR = &PINB,
+	.Number = PORTB2,
+	.Direction = OUTPUT,
+	.PullUp = false
+};
+
+/*! @brief Initialise IO for communication with W5100
+ *
+ *	@date 10.12.16			first implementation					*/
+void w51eInit(void)
+{
+	// Set up GPIO
+	ioInitPin(csPinW5100);
+
+	// Default CS disabled
+	ioWritePin(csPinW5100, HIGH);
+}
+
+/*!	@brief Write data to W5100 register
+ *
+ *	@param[in] reg			Target register
+ *	@param[in] data			Data to write into register
+ *	@date 10.12.16			first implementation					*/
+void w51eWrite(w51eReg_t reg, uint8_t data)
+{
+	// Enable ChipSelect
+	ioWritePin(csPinW5100, LOW);
+
+	if (spiTransfer(0xF0) != 0x00)	// "Read" opcode
+	{
+		ioWritePin(csPinW5100, HIGH);
+		return;
+	}
+	if (spiTransfer(reg >> 8) != 0x01)	// Address high byte
+	{
+		ioWritePin(csPinW5100, HIGH);
+		return;
+	}
+	if(spiTransfer(reg) != 0x02) // Address low byte
+	{
+		ioWritePin(csPinW5100, HIGH);
+		return;
+	}
+	if(spiTransfer(data) != 0x03)
+	{
+		ioWritePin(csPinW5100, HIGH);
+		return;
+	}
+
+	// Disable ChipSelect
+	ioWritePin(csPinW5100, HIGH);
+}
+
+/*! @brief Read data from W5100 register
+ *
+ *	@return uint8_t			Data from register
+ *	@date 10.12.16			first implementation					*/
+uint8_t w51eRead(w51eReg_t reg)
+{
+	uint8_t c;
+
+	// Enable ChipSelect
+	ioWritePin(csPinW5100, LOW);
+
+	// Transmit frame and read data
+	if (spiTransfer(0x0F) != 0x00)	// "Read" opcode
+	{
+		ioWritePin(csPinW5100, HIGH);
+		return 0x00;
+	}
+	if (spiTransfer(reg >> 8) != 0x01)	// Address high byte
+	{
+		ioWritePin(csPinW5100, HIGH);
+		return 0x00;
+	}
+	if(spiTransfer(reg & 0x00FF) != 0x02) // Address low byte
+	{
+		ioWritePin(csPinW5100, HIGH);
+		return 0x00;
+	}
+	c = spiTransfer(0xFF);
+
+
+	// Disable ChipSelect
+	ioWritePin(csPinW5100, HIGH);
+
+	return c;
+}
+

--- a/drivers/W5100/W5100.h
+++ b/drivers/W5100/W5100.h
@@ -1,0 +1,381 @@
+/*! @brief Wiznet W5100 Ethernet Controller driver headers
+ *
+ *	@author	inselc
+ *	@date	07.12.16		initial version							*/ 
+
+
+#ifndef W5100_H_
+#define W5100_H_
+
+#include <stdint.h>
+
+/* @file */
+
+#define W5100_MR_RST	7	/* MR Reset */
+#define W5100_MR_PB		4	/* MR Ping block mode */
+#define W5100_MR_PPPoE	3	/* MR PPPoE mode */
+#define W5100_MR_AI		1	/* MR Address auto-increment in Bus I/F */
+#define W5100_MR_IND	0	/* MR Indirect Bus I/F mode */
+
+#define W5100_IR_CONFLICT	7	/* IR Conflict flag */
+#define W5100_IR_UNREACH	6	/* IR Unreachable flag */
+#define W5100_IR_PPPoE		5	/* IR PPPoE conn close flag */
+#define W5100_IR_S3_INT		3	/* IR Socket 3 interrupt flag */
+#define W5100_IR_S2_INT		2	/* IR Socket 2 interrupt flag */
+#define W5100_IR_S1_INT		1	/* IR Socket 1 interrupt flag */
+#define W5100_IR_S0_INT		0	/* IR Socket 0 interrupt flag */
+
+#define W5100_IM_IR7	7	/* IM Conflict int enable */
+#define W5100_IM_IR6	6	/* IM Destination unreachable int enable */
+#define W5100_IM_IR5	5	/* IM PPPoE close int enable */
+#define W5100_IM_IR3	3	/* IM Socket 3 int enable */
+#define W5100_IM_IR2	2	/* IM Socket 2 int enable */
+#define W5100_IM_IR1	1	/* IM Socket 1 int enable */
+#define W5100_IM_IR0	0	/* IM Socket 0 int enable */
+
+#define W5100_RTR_FACTOR_100us 1	/* LSB = 100us */
+
+#define W5100_MSR_S0	0	/* Mem Size Socket 0 */
+#define W5100_MSR_S1	2	/* Mem Size Socket 0 */
+#define W5100_MSR_S2	4	/* Mem Size Socket 0 */
+#define W5100_MSR_S3	6	/* Mem Size Socket 0 */
+#define W5100_MSR_1K		0x00
+#define W5100_MSR_2K		0x01
+#define W5100_MSR_4K		0x02
+#define W5100_MSR_8K		0x03
+
+#define W5100_PATR_PAP	0xC023
+#define W5100_PATR_CHAP	0xC223
+
+#define W5100_PTIMER_FACTOR_25ms	1	/* LSB = 25ms */
+
+#define W5100_Sn_MR_MULTI	7	/* Socket n Multicast enable */
+#define W5100_Sn_MR_MF		6	/* Socket n MAC filter enable */
+#define W5100_Sn_MR_NDMC	5	/* Socket n Use No Delayed ACK */
+#define W5100_Sn_MR_PROTO	0	/* Socket n Protocol */
+#define W5100_Sn_MR_PROTO_Closed	0x00
+#define W5100_Sn_MR_PROTO_TCP		0x01
+#define W5100_Sn_MR_PROTO_UDP		0x02
+#define W5100_Sn_MR_PROTO_IPRAW		0x03
+#define W5100_Sn_MR_PROTO_MACRAW	0x04 /* Socket 0 only */
+#define W5100_Sn_MR_PROTO_PPPoE		0x05 /* Socket 0 only */
+
+#define W5100_Sn_CR_OPEN	0x01
+#define W5100_Sn_CR_LISTEN	0x02
+#define W5100_Sn_CR_CONNECT	0x04
+#define W5100_Sn_CR_DISCON	0x08
+#define W5100_Sn_CR_CLOSE	0x10
+#define W5100_Sn_CR_SEND	0x20
+#define W5100_Sn_CR_SEND_MAC 0x21
+#define W5100_Sn_CR_SEND_KEEP 0x22
+#define W5100_Sn_CR_RECV	0x40
+
+#define W5100_Sn_IR_SEND_OK	4	/* Send completed flag */
+#define W5100_Sn_IR_TIMEOUT	3
+#define W5100_Sn_IR_RECV	2	/* Receiveing data */
+#define W5100_Sn_IR_DISCON	1	/* Connection terminated */
+#define W5100_Sn_IR_CON		0	/* Connection established */
+
+#define W5100_Sn_SR_SOCK_CLOSED 0x00
+#define W5100_Sn_SR_SOCK_INIT	0x13
+#define W5100_Sn_SR_SOCK_LISTEN 0x14
+#define W5100_Sn_SR_SOCK_ESTABLISHED 0x17
+#define W5100_Sn_SR_SOCK_CLOSE_WAIT	0x1C
+#define W5100_Sn_SR_SOCK_UDP	0x22
+#define W5100_Sn_SR_SOCK_IPRAW	0x32
+#define W5100_Sn_SR_SOCK_MACRAW 0x42
+#define W5100_Sn_SR_SOCK_PPPOE	0x5F
+
+#define W5100_Sn_SR_SOCK_SYNSENT 0x15
+#define W5100_Sn_SR_SOCK_SYNRECV 0x16
+#define W5100_Sn_SR_SOCK_FIN_WAIT 0x18
+#define W5100_Sn_SR_SOCK_CLOSING 0x1A
+#define W5100_Sn_SR_SOCK_TIME_WAIT 0x1B
+#define W5100_Sn_SR_SOCK_LAST_ACK 0x1D
+#define W5100_Sn_SR_SOCK_ARP	 0x01
+
+typedef enum tagW51eReg_t{	
+	/* -- Common registers -- */
+	/* Mode */
+	W5100_REG_MR	= 0x0000,
+	/* Gateway address */
+	W5100_REG_GAR0	= 0x0001,
+	W5100_REG_GAR1	= 0x0002,
+	W5100_REG_GAR2	= 0x0003,
+	W5100_REG_GAR3	= 0x0004,
+	/* Subnet mask address */
+	W5100_REG_SUBR0	= 0x0005,
+	W5100_REG_SUBR1 = 0x0006,
+	W5100_REG_SUBR2 = 0x0007,
+	W5100_REG_SUBR3 = 0x0008,
+	/* Source hardware address (MAC) */
+	W5100_REG_SHAR0 = 0x0009,
+	W5100_REG_SHAR1 = 0x000A,
+	W5100_REG_SHAR2 = 0x000B,
+	W5100_REG_SHAR3 = 0x000C,
+	W5100_REG_SHAR4 = 0x000D,
+	W5100_REG_SHAR5 = 0x000E,
+	/* Source IP address */
+	W5100_REG_SIPR0	= 0x000F,
+	W5100_REG_SIPR1	= 0x0010,
+	W5100_REG_SIPR2 = 0x0011,
+	W5100_REG_SIPR3	= 0x0012,
+	/* reserved 0x0013 - 0x0014 */
+	/* Interrupt */
+	W5100_REG_IR	= 0x0015,
+	/* Interrupt mask */
+	W5100_REG_IMR	= 0x0016,
+	/* Retry time */
+	W5100_REG_RTR0	= 0x0017,
+	W5100_REG_RTR1	= 0x0018,
+	/* Retry count */
+	W5100_REG_RCR	= 0x0019,
+	/* RX memory size */
+	W5100_REG_RMSR	= 0x001A,
+	/* TX memory size */
+	W5100_REG_TMSR	= 0x001B,
+	/* PPPoE Authentication Type */
+	W5100_REG_PATR0	= 0x001C,
+	W5100_REG_PATR1	= 0x001D,
+	/* reserved 0x001E - 0x0027 */
+	/* PPP LCP Request Timer */
+	W5100_REG_PTIMER= 0x0028,
+	/* PPP LCP Magic Number */
+	W5100_REG_PMAGIC= 0x0029,
+	/* Unreachable IP address */
+	W5100_REG_UIPR0	= 0x002A,
+	W5100_REG_UIPR1 = 0x002B,
+	W5100_REG_UIPR2 = 0x002C,
+	W5100_REG_UIPR3 = 0x002D,
+	/* Unreachable Port */
+	W5100_REG_UPORT0= 0x002E,
+	W5100_REG_UPORT1= 0x002F,
+	/* reserved 0x0030 - 0x03FF */
+	
+	/* -- Socket 0 registers -- */
+	/* Socket 0 Mode */
+	W5100_REG_S0_MR	= 0x0400,
+	/* Socket 0 Command */
+	W5100_REG_S0_CR	= 0x0401,
+	/* Socket 0 Interrupt */
+	W5100_REG_S0_IR	= 0x0402,
+	/* Socket 0 Status */
+	W5100_REG_S0_SR	= 0x0403,
+	/* Socket 0 Source Port */
+	W5100_REG_S0_PORT0 = 0x0404,
+	W5100_REG_S0_PORT1 = 0x0405,
+	/* Socket 0 Destination Hardware Address */
+	W5100_REG_S0_DHAR0 = 0x0406,
+	W5100_REG_S0_DHAR1 = 0x0407,
+	W5100_REG_S0_DHAR2 = 0x0408,
+	W5100_REG_S0_DHAR3 = 0x0409,
+	W5100_REG_S0_DHAR4 = 0x040A,
+	W5100_REG_S0_DHAR5 = 0x040B,
+	/* Socket 0 Destination IP Address */
+	W5100_REG_S0_DIPR0 = 0x040C,
+	W5100_REG_S0_DIPR1 = 0x040D,
+	W5100_REG_S0_DIPR2 = 0x040E,
+	W5100_REG_S0_DIPR3 = 0x040F,
+	/* Socket 0 Destination Port */
+	W5100_REG_S0_DPORT0 = 0x0410,
+	W5100_REG_S0_DPORT1 = 0x0411,
+	/* Socket 0 max. segment size */
+	W5100_REG_S0_MSSR0 = 0x0412,
+	W5100_REG_S0_MSSR1 = 0x0413,
+	/* Socket 0 Protocol in IP Raw Mode */
+	W5100_REG_S0_PROTO = 0x0414,
+	/* Socket 0 IP TOS */
+	W5100_REG_S0_TOS = 0x0415,
+	/* Socket 0 IP TTL */
+	W5100_REG_S0_TTL = 0x0416,
+	/* reserved 0x0417 - 0x041F */
+	/* Socket 0 TX free size */
+	W5100_REG_S0_TX_FSR0 = 0x0420,
+	W5100_REG_S0_TX_FSR1 = 0x0421,
+	/* Socket 0 TX read pointer */
+	W5100_REG_S0_TX_RD0 = 0x0422,
+	W5100_REG_S0_TX_RD1 = 0x0423,
+	/* Socket 0 TX write pointer */
+	W5100_REG_S0_TX_WR0 = 0x0424,
+	W5100_REG_S0_TX_WR1 = 0x0425,
+	/* Socket 0 RX received size */
+	W5100_REG_S0_RX_RSR0 = 0x0426,
+	W5100_REG_S0_RX_RSR1 = 0x0427,
+	/* Socket 0 RX read pointer */ 
+	W5100_REG_S0_RX_RD0 = 0x0428,
+	W5100_REG_S0_RX_RD1 = 0x0429,
+	/* reserved 0x042A - 0x042B */
+	/* reserved 0x042C - 0x04FF */
+
+	/* -- Socket 11 registers -- */
+	/* Socket 11 Mode */
+	W5100_REG_S1_MR	= 0x0500,
+	/* Socket 11 Command */
+	W5100_REG_S1_CR	= 0x0501,
+	/* Socket 11 Interrupt */
+	W5100_REG_S1_IR	= 0x0502,
+	/* Socket 11 Status */
+	W5100_REG_S1_SR	= 0x0503,
+	/* Socket 11 Source Port */
+	W5100_REG_S1_PORT0 = 0x0504,
+	W5100_REG_S1_PORT1 = 0x0505,
+	/* Socket 11 Destination Hardware Address */
+	W5100_REG_S1_DHAR0 = 0x0506,
+	W5100_REG_S1_DHAR1 = 0x0507,
+	W5100_REG_S1_DHAR2 = 0x0508,
+	W5100_REG_S1_DHAR3 = 0x0509,
+	W5100_REG_S1_DHAR4 = 0x050A,
+	W5100_REG_S1_DHAR5 = 0x050B,
+	/* Socket 11 Destination IP Address */
+	W5100_REG_S1_DIPR0 = 0x050C,
+	W5100_REG_S1_DIPR1 = 0x050D,
+	W5100_REG_S1_DIPR2 = 0x050E,
+	W5100_REG_S1_DIPR3 = 0x050F,
+	/* Socket 11 Destination Port */
+	W5100_REG_S1_DPORT0 = 0x0510,
+	W5100_REG_S1_DPORT1 = 0x0511,
+	/* Socket 11 max. segment size */
+	W5100_REG_S1_MSSR0 = 0x0512,
+	W5100_REG_S1_MSSR1 = 0x0513,
+	/* Socket 11 Protocol in IP Raw Mode */
+	W5100_REG_S1_PROTO = 0x0514,
+	/* Socket 11 IP TOS */
+	W5100_REG_S1_TOS = 0x0515,
+	/* Socket 11 IP TTL */
+	W5100_REG_S1_TTL = 0x0516,
+	/* reserved 0x0517 - 0x051F */
+	/* Socket 11 TX free size */
+	W5100_REG_S1_TX_FSR0 = 0x0520,
+	W5100_REG_S1_TX_FSR1 = 0x0521,
+	/* Socket 11 TX read pointer */
+	W5100_REG_S1_TX_RD0 = 0x0522,
+	W5100_REG_S1_TX_RD1 = 0x0523,
+	/* Socket 11 TX write pointer */
+	W5100_REG_S1_TX_WR0 = 0x0524,
+	W5100_REG_S1_TX_WR1 = 0x0525,
+	/* Socket 11 RX received size */
+	W5100_REG_S1_RX_RSR0 = 0x0526,
+	W5100_REG_S1_RX_RSR1 = 0x0527,
+	/* Socket 11 RX read pointer */
+	W5100_REG_S1_RX_RD0 = 0x0528,
+	W5100_REG_S1_RX_RD1 = 0x0529,
+	/* reserved 0x052A - 0x052B */
+	/* reserved 0x052C - 0x05FF */
+
+	/* -- Socket 2 registers -- */
+	/* Socket 2 Mode */
+	W5100_REG_S2_MR	= 0x0600,
+	/* Socket 2 Command */
+	W5100_REG_S2_CR	= 0x0601,
+	/* Socket 2 Interrupt */
+	W5100_REG_S2_IR	= 0x0602,
+	/* Socket 2 Status */
+	W5100_REG_S2_SR	= 0x0603,
+	/* Socket 2 Source Port */
+	W5100_REG_S2_PORT0 = 0x0604,
+	W5100_REG_S2_PORT1 = 0x0605,
+	/* Socket 2 Destination Hardware Address */
+	W5100_REG_S2_DHAR0 = 0x0606,
+	W5100_REG_S2_DHAR1 = 0x0607,
+	W5100_REG_S2_DHAR2 = 0x0608,
+	W5100_REG_S2_DHAR3 = 0x0609,
+	W5100_REG_S2_DHAR4 = 0x060A,
+	W5100_REG_S2_DHAR5 = 0x060B,
+	/* Socket 2 Destination IP Address */
+	W5100_REG_S2_DIPR0 = 0x060C,
+	W5100_REG_S2_DIPR1 = 0x060D,
+	W5100_REG_S2_DIPR2 = 0x060E,
+	W5100_REG_S2_DIPR3 = 0x060F,
+	/* Socket 2 Destination Port */
+	W5100_REG_S2_DPORT0 = 0x0610,
+	W5100_REG_S2_DPORT1 = 0x0611,
+	/* Socket 2 max. segment size */
+	W5100_REG_S2_MSSR0 = 0x0612,
+	W5100_REG_S2_MSSR1 = 0x0613,
+	/* Socket 2 Protocol in IP Raw Mode */
+	W5100_REG_S2_PROTO = 0x0614,
+	/* Socket 2 IP TOS */
+	W5100_REG_S2_TOS = 0x0615,
+	/* Socket 2 IP TTL */
+	W5100_REG_S2_TTL = 0x0616,
+	/* reserved 0x0617 - 0x061F */
+	/* Socket 2 TX free size */
+	W5100_REG_S2_TX_FSR0 = 0x0620,
+	W5100_REG_S2_TX_FSR1 = 0x0621,
+	/* Socket 2 TX read pointer */
+	W5100_REG_S2_TX_RD0 = 0x0622,
+	W5100_REG_S2_TX_RD1 = 0x0623,
+	/* Socket 2 TX write pointer */
+	W5100_REG_S2_TX_WR0 = 0x0624,
+	W5100_REG_S2_TX_WR1 = 0x0625,
+	/* Socket 2 RX received size */
+	W5100_REG_S2_RX_RSR0 = 0x0626,
+	W5100_REG_S2_RX_RSR1 = 0x0627,
+	/* Socket 2 RX read pointer */
+	W5100_REG_S2_RX_RD0 = 0x0628,
+	W5100_REG_S2_RX_RD1 = 0x0629,
+	/* reserved 0x062A - 0x062B */
+	/* reserved 0x062C - 0x06FF */
+
+	/* -- Socket 3 registers -- */
+	/* Socket 3 Mode */
+	W5100_REG_S3_MR	= 0x0700,
+	/* Socket 3 Command */
+	W5100_REG_S3_CR	= 0x0701,
+	/* Socket 3 Interrupt */
+	W5100_REG_S3_IR	= 0x0702,
+	/* Socket 3 Status */
+	W5100_REG_S3_SR	= 0x0703,
+	/* Socket 3 Source Port */
+	W5100_REG_S3_PORT0 = 0x0704,
+	W5100_REG_S3_PORT1 = 0x0705,
+	/* Socket 3 Destination Hardware Address */
+	W5100_REG_S3_DHAR0 = 0x0706,
+	W5100_REG_S3_DHAR1 = 0x0707,
+	W5100_REG_S3_DHAR2 = 0x0708,
+	W5100_REG_S3_DHAR3 = 0x0709,
+	W5100_REG_S3_DHAR4 = 0x070A,
+	W5100_REG_S3_DHAR5 = 0x070B,
+	/* Socket 3 Destination IP Address */
+	W5100_REG_S3_DIPR0 = 0x070C,
+	W5100_REG_S3_DIPR1 = 0x070D,
+	W5100_REG_S3_DIPR2 = 0x070E,
+	W5100_REG_S3_DIPR3 = 0x070F,
+	/* Socket 3 Destination Port */
+	W5100_REG_S3_DPORT0 = 0x0710,
+	W5100_REG_S3_DPORT1 = 0x0711,
+	/* Socket 3 max. segment size */
+	W5100_REG_S3_MSSR0 = 0x0712,
+	W5100_REG_S3_MSSR1 = 0x0713,
+	/* Socket 3 Protocol in IP Raw Mode */
+	W5100_REG_S3_PROTO = 0x0714,
+	/* Socket 3 IP TOS */
+	W5100_REG_S3_TOS = 0x0715,
+	/* Socket 3 IP TTL */
+	W5100_REG_S3_TTL = 0x0716,
+	/* reserved 0x0717 - 0x071F */
+	/* Socket 3 TX free size */
+	W5100_REG_S3_TX_FSR0 = 0x0720,
+	W5100_REG_S3_TX_FSR1 = 0x0721,
+	/* Socket 3 TX read pointer */
+	W5100_REG_S3_TX_RD0 = 0x0722,
+	W5100_REG_S3_TX_RD1 = 0x0723,
+	/* Socket 3 TX write pointer */
+	W5100_REG_S3_TX_WR0 = 0x0724,
+	W5100_REG_S3_TX_WR1 = 0x0725,
+	/* Socket 3 RX received size */
+	W5100_REG_S3_RX_RSR0 = 0x0726,
+	W5100_REG_S3_RX_RSR1 = 0x0727,
+	/* Socket 3 RX read pointer */
+	W5100_REG_S3_RX_RD0 = 0x0728,
+	W5100_REG_S3_RX_RD1 = 0x0729,
+	/* reserved 0x072A - 0x072B */
+	/* reserved 0x072C - 0x07FF */
+} w51eReg_t;
+
+// Low level Device-specific implementation 
+void w51eInit(void);
+void w51eWrite(w51eReg_t reg, uint8_t data);
+uint8_t w51eRead(w51eReg_t reg);
+
+#endif /* W5100_H_ */

--- a/modules/io/io.h
+++ b/modules/io/io.h
@@ -1,0 +1,155 @@
+/*! @brief I/O definitions
+ *
+ *	@author	inselc
+ *	@date	04.12.16	initial version								*/
+
+#ifndef IO_H_
+#define IO_H_
+
+/*! @file */
+
+#include <stdint.h>
+#include <stdbool.h>
+
+#define LOW		false	/*!< Logic LOW pin state representation		*/
+#define HIGH	true	/*!< Logic HIGH pin state representation	*/
+
+/*! @enum pinDir_t 
+ *  @brief I/O pin direction option									*/
+typedef enum tagPinDir_t
+{
+	INPUT = 0,
+	OUTPUT = 1
+} pinDir_t;
+
+/*! @struct	pin_t
+ *  @brief I/O pin type
+ *  @var pin_t::Port
+ *  Port register address of the selected pin (e.g. &PORTD).
+ *  @var pin_t::DDR
+ *  Direction register address of the selected pin (e.g. &DDRD).
+ *  @var pin_t::PINR
+ *	PIN Register name of the selected pin (e.g. &PIND).
+ *  @var pin_t::Number
+ *  Number (0...8) of the pin at the selected port (e.g. PORTD5, or 5).
+ *	@var pin_t::Direction
+ *	Input/Output configuration
+ *	@var pin_t::PullUp
+ *	Pull-Up resistor enabled state									*/
+typedef struct tagPin_t
+{
+	volatile uint8_t*	Port;
+	volatile uint8_t*	DDR;
+	volatile uint8_t*	PINR;
+	uint8_t				Number;
+	pinDir_t			Direction;
+	bool				PullUp;
+} pin_t;
+
+/*! @brief Set direction of I/O pin
+ * 
+ *	@note Will leave pin in safe mode for PullUp configuration
+ *
+ *  @param[inout] *pin		Selected pin configuration
+ *  @param[in] direction	New pin direction (INPUT/OUTPUT)
+ *  @date 04.12.16			first implementation					*/
+inline void ioSetPinDirection(pin_t* pin, pinDir_t direction)
+{
+	// update configuration
+	pin->Direction = direction;
+
+	// set up safe transition state  (Tri-State) as per
+	// datasheet p. 99 (18.2.3 Switching Between Input and Output
+	*pin->DDR &= ~(1 << pin->Number);
+	*pin->Port &= ~(1 << pin->Number);
+
+	// apply new configuration
+	*pin->DDR &= ~(!direction << pin->Number);
+	*pin->DDR |= direction << pin->Number;
+}
+
+/*! @brief Read the digital pin state
+ *
+ *  @param[in] pin			Selected pin
+ *	@return bool			Pin state
+ *  @date 04.12.16			first implementation					*/
+inline bool ioReadPin(pin_t pin)
+{
+	// return pin state as boolean
+	return (bool)(*pin.Port & (1 << pin.Number));
+}
+
+/*! @brief Set the digital pin state
+ * 
+ *	@param[in] pin			Target pin
+ *	@param[in] state		Output state
+ *	@date 04.12.16			first implementation					*/
+inline void ioWritePin(pin_t pin, bool state)
+{
+	// apply new state to pin output
+	*pin.Port &= ~(!state << pin.Number);
+	*pin.Port |= state << pin.Number;
+}
+
+/*! @brief Configure Pull-ups for I/O pin
+ *
+ *	@warning Pin must be set into safe configuration for transition beforehand!
+ * 
+ *	@param[inout] pin		Selected pin configuration
+ *	@param[in] pullUpEnable	New pullup-disable state
+ *	@data 04.12.16			first implementation					*/
+inline void ioSetPinPullup(pin_t* pin, bool pullUpEnable)
+{
+	// apply pull-up only, if pin direction is an output.
+	if (pin->Direction == INPUT)
+	{
+		// update configuration
+		pin->PullUp = pullUpEnable;
+
+		// Apply pull-up configuration as per
+		// datasheet p. 99 (18.2.3 Switching Between Input and Output)
+		ioWritePin(*pin, pin->PullUp);
+	}
+}
+
+/*! @brief Apply pin configuration to hardware
+ *
+ *	@note Outputs will be initialised with a default LOW state.
+ *
+ *	@param[in] pinConf		Pin configuration
+ *	@date 04.12.16			first implementation					*/
+inline void ioInitPin(pin_t pinConf)
+{
+	// Set pin direction in DDR
+	ioSetPinDirection(&pinConf, pinConf.Direction);
+	// Set pull-up configuration, if pin is an input
+	ioSetPinPullup(&pinConf, pinConf.PullUp);
+}
+
+/*! @brief Globally disable pull-up resistors via the MCUCR PUD bit.
+ *
+ *	@param[in] PUDisable	Disable all pull-up resistors
+ *	@date 04.12.16			first implementation					*/
+inline void ioSetGlobalPullUp(bool PUDisable)
+{
+	MCUCR &= ~(PUDisable << PUD);
+	MCUCR |= !PUDisable << PUD;
+}
+
+/*! @brief Toggle pin state between HIGH and LOW, if pin is configured as output.
+ *
+ *  @note Pin must be configured as an output!
+ * 
+ *	@param[in] pin			Target pin
+ *	@date 04.12.16			first implementation					*/
+inline void ioTogglePin(pin_t pin)
+{
+	//if ( (*pin.DDR & (1 << pin.Number)) && (pin.Direction == OUTPUT) )
+	{
+		// The PIN register is a W1T-type register as per
+		// datasheet p. 99 (18.2.2 Toggling the Pin)
+		*pin.PINR = 1 << pin.Number;
+	}
+}
+
+#endif /* IO_H_ */

--- a/modules/spi/spi.h
+++ b/modules/spi/spi.h
@@ -1,0 +1,16 @@
+/*! @brief Top-level SPI header file
+ *
+ *	@author	inselc
+ *	@date	05.12.16	initial version								*/
+
+#ifndef SPI_H_
+#define SPI_H_
+
+#include <stdint.h>
+#include <stdbool.h>  
+#include <avr/io.h>
+
+#include "spi_common.h"
+#include "spi_master.h"
+
+#endif /* SPI_H_ */

--- a/modules/spi/spi_common.h
+++ b/modules/spi/spi_common.h
@@ -1,0 +1,186 @@
+/*! @brief Common SPI definitions
+ *
+ *	@author	inselc
+ *	@date	05.12.16	initial version								*/ 
+
+
+#ifndef SPI_COMMON_H_
+#define SPI_COMMON_H_
+
+#include <stdbool.h>
+#include <stdint.h>
+
+/*! @file */
+
+/*! @enum spiMode_t
+ *	SPI Master/Slave mode configuration								*/
+typedef enum tagSpiMode_t 
+{
+	SPI_SLAVE = 0,
+	SPI_MASTER = 1
+} spiMode_t;
+
+/*! @enum spiDataOrder_t
+ *	SPI Data Order mode												*/
+typedef enum tagSpiDataOrder_t 
+{
+	SPI_MSBFIRST = 0,
+	SPI_LSBFIRST = 1
+} spiDataOrder_t;
+
+/*! @enum spiClkMode_t
+ *	SPI Clock Mode selector											*/
+typedef enum tagSpiClkMode_t
+{
+	SPI_MODE0 = 0x00,
+	SPI_MODE1 = 0x01,
+	SPI_MODE2 = 0x02,
+	SPI_MODE3 = 0x03
+} spiClkMode_t;
+
+/*! @brief Enable SPI module power
+ *
+ *	@date 04.12.16			first implementation					*/
+inline void spiPowerEnable(void)
+{
+	// Enable SPI module in the power reduction register as per
+	// datasheet p. 215 (23.2 Overview)
+	PRR &= ~(1 << PRSPI);
+}
+
+/*! @brief Disable SPI module power
+ *
+ *	@date 04.12.16			first implementation					*/
+inline void spiPowerDisable(void)
+{
+	// Disable SPI module in the power reduction register as per
+	// datasheet p. 215 (23.2 Overview)
+	PRR |= 1 << PRSPI;
+}
+
+/*! @brief Enable SPI function
+ *
+ *	@date 05.12.16			first implementation					*/
+inline void spiEnable(void)
+{
+	SPCR |= 1 << SPE;
+}
+
+/*! @brief Disable SPI function
+ *
+ *	@date 05.12.16			first implementation					*/
+inline void spiDisable(void)
+{
+	SPCR &= ~(1 << SPE);
+}
+
+/*! @brief Select SPI Slave or Master configuration
+ *
+ *	@param[in] mode			Slave/Master mode
+ *	@date 05.12.16			first implementation					*/
+inline void spiSetMstrSlave(spiMode_t mode)
+{
+	// Set/Clear SPI master mode in SPCR as per datasheet 
+	// p. 221 (23.5.1 SPI Control Register 0)
+	SPCR &= ~(!mode << MSTR);
+	SPCR |= mode << MSTR;
+}
+
+/*! @brief Apply SPI Clock mode configuration (polarity and phase)
+ *
+ *	See Datasheet p. 221f for information on SPI modes.
+ *
+ *	@param[in] mode			SPI Mode (0...3)
+ *	@date 05.12.16			first implementation					*/
+inline void spiSetClkMode(spiClkMode_t mode)
+{
+	// Set/Clear SPI clock polarity and phase as per datasheet
+	// p. 221f (23.5.1 SPI Control Register 0)
+	SPCR &= ~((~mode)&0x03 << CPHA);
+	SPCR |= mode << CPHA;
+}
+
+/*!	@brief Setup SPI data order
+ *
+ *	@param[in] order		Data direction LSB or MSB first
+ *	@date 05.12.16			first implementation					*/
+inline void spiSetDataOrder(spiDataOrder_t order)
+{
+	SPCR &= ~(!order << DORD);
+	SPCR |= order << DORD;
+}
+
+/*! @brief Get SPI interrupt flag state
+ *
+ *	@date 05.12.16			first implementation					*/
+inline bool spiGetIF(void)
+{
+	// Get interrupt flag state
+	// see datasheet p. 223 (25.3.2 SPI Status Register 0)
+	return (bool)(SPSR & (1 << SPIF));
+}
+
+/*! @brief Clear SPI interrupt flag
+ *
+ *  Manual SPIF clear. The flag will get cleared automatically,
+ *  when first reading SPSR with SPIF set, and then accessing
+ *  SPDR (see datasheet p. 223, 23.5.2 SPI Status Register 0).
+ *
+ *	@date 05.12.16			first implementation					*/
+inline void spiClrIF(void)
+{
+	// Clear interrupt flag
+	SPSR &= (1 << SPIF);
+}
+
+/*! @brief Send byte over SPI
+ *
+ *	@param[in] data			Byte to be transmitted
+ *	@date 05.12.16			first implementation					*/
+inline void spiTxByte(uint8_t data)
+{
+	SPDR = data;
+}
+
+/*! @brief Send byte over SPI and wait for SPIF
+ *
+ *	@param[in] data			Byte to be transmitted
+ *	@date 07.12.16			first implementation					*/
+inline void spiTxByteWait(uint8_t data)
+{
+	spiTxByte(data);
+
+	while(!spiGetIF()){;}
+}
+
+/*! @brief Read byte from SPI
+ *
+ *	@return	uint8_t			Data from SPI data register (SPDR)
+ *	@date 05.12.16			first implementation					*/
+inline uint8_t spiRxByte(void)
+{
+	return SPDR;
+}
+
+/*! @brief Wait for SPIF and read byte from SPI
+ *
+ *	This will automatically clear the SPIF after reading the data
+ *  from SPDR (see datasheet p. 223, 23.5.2 SPI Status Register 0). 
+ *
+ *	@return uint8_t			Data from SPI data register (SPDR)
+ *	@date 05.12.16			first implementation					*/
+inline uint8_t spiWaitRxByte(void)
+{
+	// Poll SPIF until set
+	while(!spiGetIF()){;}
+
+	return spiRxByte();
+}
+
+inline uint8_t spiTransfer(uint8_t data)
+{
+	SPDR = data;
+	while (!(SPSR & (1 << SPIF))){;}
+	return SPDR;
+}
+#endif /* SPI_COMMON_H_ */

--- a/modules/spi/spi_master.c
+++ b/modules/spi/spi_master.c
@@ -1,0 +1,44 @@
+/*
+ * spi_master.c
+ *
+ * Created: 12/10/2016 10:05:17 PM
+ *  Author: inselc
+ */ 
+
+#include <avr/io.h>
+#include "spi_master.h"
+
+/*! @brief Initialise SPI in Master mode
+ *
+ *	@param[in] clkRate		Clock speed
+ *	@param[in] clkMode		Clock mode (0...3)
+ *	@param[in] dataOrder	Data order (MSB or LSB first)
+ *	@date 05.12.16			first implementation					*/
+void spiInitMaster(spiClkRate_t clkRate, spiClkMode_t clkMode, spiDataOrder_t dataOrder)
+{
+	// Enable SPI module power
+	spiPowerEnable();
+
+	// make sure SPI is disabled for setup
+	spiDisable();
+
+	// configure as SPI Master
+	spiSetMstrSlave(SPI_MASTER);
+
+	// set SPI data order
+	spiSetDataOrder(dataOrder);
+
+	// apply clock configuration
+	spiSetClkMode(clkMode);
+	spiSetMstrClkRate(clkRate);
+	
+	// Set PB5(SCK) abd PB3 (MOSI) as outputs
+	DDRB |= (1 << 5) | (1 << 3);
+	// Disable pull-up on PB4 (MISO)
+	PORTB &= ~(1 << 4);
+	// Set PB4 (MISO) as input
+	DDRB &= ~(1 << 4);
+
+	// enable SPI
+	spiEnable();
+}

--- a/modules/spi/spi_master.h
+++ b/modules/spi/spi_master.h
@@ -1,0 +1,43 @@
+/*! @brief SPI Master-mode definitions
+ *
+ *	@author	inselc
+ *	@date	05.12.16	initial version								*/ 
+
+#ifndef SPI_MASTER_H_
+#define SPI_MASTER_H_
+
+/*! @file */
+
+#include "spi_common.h"
+
+/*!	@enum spiClkRate_t
+ *	SPI Clock divider rate selector									*/
+typedef enum tagSpiClkRate_t 
+{
+	SPI_FOSC_DIV_2  = 0x04,
+	SPI_FOSC_DIV_4  = 0x00,
+	SPI_FOSC_DIV_8  = 0x05,
+	SPI_FOSC_DIV_16 = 0x01,
+	SPI_FOSC_DIV_32 = 0x06,
+	SPI_FOSC_DIV_64 = 0x02,
+	SPI_FOSC_DIV_128= 0x03
+} spiClkRate_t;
+
+/*! @brief Set SPI Clock rate in Master mode
+ *
+ *	@param[in] rate			SPI Clock rate
+ *	@date 05.12.16			first implementation					*/
+inline void spiSetMstrClkRate(spiClkRate_t rate)
+{
+	// SPI Double Speed bit
+	SPSR &= ~((((~rate)&0x04) >> 2) << SPI2X);
+	SPSR |= ((rate&0x04) >> 2) << SPI2X;
+
+	// SPI Clock Rate Select
+	SPCR &= ~(((~rate)&0x03) << SPR0);
+	SPCR |= (rate&0x03) << SPR0;
+}
+
+void spiInitMaster(spiClkRate_t clkRate, spiClkMode_t clkMode, spiDataOrder_t dataOrder);
+
+#endif /* SPI_MASTER_H_ */

--- a/modules/spi/spi_slave.h
+++ b/modules/spi/spi_slave.h
@@ -1,0 +1,14 @@
+/*! @brief SPI Slave-mode definitions
+ *
+ *	@author	inselc
+ *	@date	04.12.16	initial version								*/ 
+
+
+#ifndef SPI_SLAVE_H_
+#define SPI_SLAVE_H_
+
+#include "spi_common.h"
+
+// not yet implemented
+
+#endif /* SPI_SLAVE_H_ */

--- a/modules/usart/usart_common.h
+++ b/modules/usart/usart_common.h
@@ -1,0 +1,186 @@
+/*! @brief Common USART definitions
+ *
+ *	@author	inselc
+ *	@date	05.12.16	initial version								*/ 
+
+#ifndef USART_COMMON_H_
+#define USART_COMMON_H_
+
+/*! @file */
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <avr/io.h>
+
+/*!	@enum usartMode_t
+ *	USART Module mode selector.										*/
+typedef enum tagUsartMode_t {
+	USART_MSTR_ASYNC	= 0x00,
+	USART_MSTR_SYNC		= 0x01,
+	USART_MSTR_SPI		= 0x40,
+	USART_SLAVE_SYNC	= 0x83
+} usartMode_t;
+
+/*! @enum usartBaudrate_t
+ *	USART Baud rate configuration.									*/
+typedef enum tagUsartBaudrate_t {
+	USART_BAUD_16M_2400		= 416,			// -0.1%
+	USART_BAUD_16M_2400_2X	= 832 | 0x1000,	//  0.0%
+	USART_BAUD_16M_4800		= 207,			//  0.2%
+	USART_BAUD_16M_4800_2X	= 416 | 0x1000,	// -0.1%
+	USART_BAUD_16M_9600		= 103,			//  0.2%
+	USART_BAUD_16M_9600_2X	= 207 | 0x1000,	//  0.2%
+	USART_BAUD_16M_14400	= 68,			//  0.6%
+	USART_BAUD_16M_14400_2X	= 138 | 0x1000,	// -0.1%
+	USART_BAUD_16M_19200	= 51,			//  0.2%
+	USART_BAUD_16M_19200_2X	= 103 | 0x1000,	//  0.2%
+	USART_BAUD_16M_28800	= 34,			// -0.8%
+	USART_BAUD_16M_28800_2X	= 68 | 0x1000,	//  0.6%
+	USART_BAUD_16M_38400	= 25,			//  0.2%
+	USART_BAUD_16M_38400_2X	= 51 | 0x1000,	//  0.2%
+	USART_BAUD_16M_57600	= 16,			//  2.1%
+	USART_BAUD_16M_57600_2X	= 34 | 0x1000,	// -0.8%
+	USART_BAUD_16M_76800	= 12,			//  0.2%
+	USART_BAUD_16M_76800_2X	= 25 | 0x1000,	//  0.2%
+	USART_BAUD_16M_115200	= 8,			// -3.5%
+	USART_BAUD_16M_115200_2X= 16 | 0x1000,	//  2.1%
+	USART_BAUD_16M_230400	= 3,			//  8.5%
+	USART_BAUD_16M_230400_2X= 8 | 0x1000,	// -3.5%
+	USART_BAUD_16M_250000	= 0,			//  0.0%
+	USART_BAUD_16M_250000_2X= 7 | 0x1000,	//  0.0%
+	USART_BAUD_16M_500000	= 1,			//  0.0%
+	USART_BAUD_16M_500000_2X= 3 | 0x1000,	//  0.0%
+	USART_BAUD_16M_1M		= 0,			//  0.0%
+	USART_BAUD_16M_1M_2X	= 1 | 0x1000,	//  0.0%
+	USART_BAUD_16M_2M_2X	= 0 | 0x1000	//	0.0%
+} usartBaudrate_t;
+
+/*! @brief Enable power to the USART module
+ *
+ *	See datasheet p. 225 (24.2 Overview).
+ *
+ *	@date 05.12.16				first implementation				*/
+inline void usartPowerEnable(void)
+{
+	PRR &= ~(1 << PRUSART0);
+}
+
+/*! @brief Disable power to the USART module
+ *
+ *	See datasheet p. 225 (24.2 Overview).
+ *
+ *	@date 05.12.16				first implementation				*/
+inline void usartPowerDisable(void)
+{
+	PRR |= 1 << PRUSART0;
+}
+
+/*! @brief Set USART module mode
+ *
+ *	See datasheet p. 249 (24.12.4 USART Control and Status Register 0 C).
+ *
+ *	@param[in] mode				USART mode
+ *	@date 05.12.16				first implementation				*/
+inline void usartSetMode(usartMode_t mode)
+{
+	UCSR0C &= ~(~(mode&0x03) << UPM00);
+	UCSR0C |= (mode&0x03) << UPM00;
+}
+
+/*! @brief Set USART baud rate
+ *
+ *	See datasheet p. 243 (Table 24-7 Examples of UBRRn Settings for
+ *	Commonly Used Oscillator Frequencies).
+ *
+ *	@param[in] baudrate			USART baud rate (from enum)
+ *	@date 05.12.16				first implementation				*/
+inline void usartSetBaudrate(usartBaudrate_t baudrate)
+{
+	UBRR0 = baudrate & 0x0FFF;
+
+	UCSR0A &= ~((((~baudrate)&0x1000) >> 12) << U2X0);
+	UCSR0A |= ((baudrate&0x1000) >> 12) << U2X0;
+}
+
+/*! @brief Wait until the USART data buffer is empty
+ *
+ *	@date 05.12.16				first implementation				*/
+inline void usartWaitDREmpty(void)
+{
+	while( !(UCSR0A & (1 << UDRE0)) ){;}
+}
+
+/*! @brief Enable USART RTX function
+ *
+ *	@date 05.12.16				first implementation				*/
+inline void usartEnable(void)
+{
+	UCSR0B |= (1 << TXEN0) | (1 << RXEN0);
+}
+
+/*! @brief Disable USART RTX function
+ *
+ *	@date 05.12.16				first implementation				*/
+inline void usartDisable(void)
+{
+	UCSR0B &= ~((1 << TXEN0) | (1 << RXEN0));
+}
+
+/*! @brief Send a single USART data frame
+ *
+ *	@param[in] data				Data to be transmitted
+ *	@date 05.12.16				first implementation				*/
+inline void usartSendData(uint16_t data)
+{
+	//usartWaitDREmpty();
+	UCSR0B &= ~(1 << TXB80);
+	UCSR0B |= ((data&0x0100) >> 8) << TXB80;
+	UDR0 = data;
+}
+
+/*! @brief Read up to 9 data bits from USART RX buffer
+ *
+ *  @return uint16_t			Data from RX buffer
+ *	@date 06.12.16				first implementation				*/
+inline uint16_t usartReadData9(void)
+{
+	return (UDR0) | (((UCSR0B & (1 << TXB80)) >> TXB80) << 8);
+}
+
+/*! @brief Only read up to 8 data bits from USART RX buffer
+ *
+ *	@return uint8_t				Data from RX buffer
+ *	@date 06.12.16				first implementation				*/
+inline uint8_t usartReadData(void)
+{
+	return UDR0;
+}
+
+/*! @brief Check if USART Transmit op is complete
+ *
+ *	@return bool				TXC bit state
+ *	@date 07.12.16				first implementation				*/
+inline bool usartTXC(void)
+{
+	return (UCSR0A & (1 << TXC0));
+}
+
+/*! @brief Check if USART Receive op is complete
+ *
+ *	@return bool				RXC bit state
+ *	@date 07.12.16				first implementation				*/
+inline bool usartRXC(void)
+{
+	return (UCSR0A & (1 << RXC0));
+}
+
+/*! @brief Check if USART data register is empty
+ *
+ *	@return bool				UDRE bit state
+ *	@date 07.12.16				first implementation				*/
+inline bool usartUDRE(void)
+{
+	return (UCSR0A & (1 << UDRE0));
+}
+
+#endif /* USART_COMMON_H_ */

--- a/modules/usart/usart_rs232.h
+++ b/modules/usart/usart_rs232.h
@@ -1,0 +1,112 @@
+/*! @brief RS232-specific USART definitions
+ *
+ *	@author	inselc
+ *	@date	05.12.16	initial version								*/ 
+
+#ifndef USART_RS232_H_
+#define USART_RS232_H_
+
+#include "usart_common.h"
+
+/*! @file */
+
+/*! @enum usartDataLen_t
+ *	Data length configuration										*/
+typedef enum tagUsartDataLen_t
+{
+	USART_LEN_5 = 0x00,
+	USART_LEN_6 = 0x01,
+	USART_LEN_7 = 0x02,
+	USART_LEN_8 = 0x03,
+	USART_LEN_9 = 0x07				// Not yet implemented
+} usartDataLen_t;
+
+/*! @enum usartParity_t
+ *  Parity bit configuration										*/
+typedef enum tagUsartParity_t
+{
+	USART_PARITY_NONE = 0x00,
+	USART_PARITY_EVEN = 0x02,
+	USART_PARITY_ODD  = 0x03
+} usartParity_t;
+
+/*! @enum usartSBit_t 
+ *	Stop bit count													*/
+typedef enum tagUsartSBit_t
+{
+	USART_SBIT_1 = 0,
+	USART_SBIT_2 = 1
+} usartSBit_t;
+
+/*! @brief Set USART character size / data length
+ *	
+ *	See datasheet p. 250 (Table 24-11 Character Size Settings).
+ *
+ *  @param[in] dataLen			Data length
+ *	@date 05.12.16				first implementation				*/
+inline void usartSetDataLen(usartDataLen_t dataLen)
+{
+	UCSR0B &= ~((((~dataLen)&0x04) >> 2) << UCSZ02);
+	UCSR0C &= ~(((~dataLen)&0x03) << UCSZ00);
+	UCSR0B |= ((dataLen&0x04) >> 2) << UCSZ02;
+	UCSR0C |= (dataLen&0x03) << UCSZ00;
+}
+
+/*! @brief Set USART parity bit generator configuration
+ *
+ *	See datasheet p. 249 (Table 24-9 USART Mode Selection).
+ *
+ *	@param[in] parity			Parity bit mode
+ *	@date 05.12.16				first implementation				*/
+inline void usartSetParity(usartParity_t parity)
+{
+	UCSR0C &= ~(((~parity)&0x03) << UPM00);
+	UCSR0C |= (parity&0x03) << UPM00;
+}
+
+/*! @brief Set USART stop bit configuration
+ *
+ *	See datasheet p. 250 (Table 24-10 Stop Bit Settings)
+ *
+ *	@param[in] stopBits			Stop bit configuration
+ *	@date 05.12.16				first implementation				*/
+inline void usartSetSBits(usartSBit_t stopBits)
+{	
+	UCSR0C &= ~(!stopBits << USBS0);
+	UCSR0C |= stopBits << USBS0;
+}
+
+/*! @brief Setup USART in RS232 mode
+ *
+ *	@param[in] mode				USART mode (must be R232 sync or R232 async)
+ *	@param[in] baudrate			Data baudrate
+ *	@param[in] dataLen			Data length per frame (5...9)
+ *	@param[in] parity			Parity mode (none, even, odd)
+ *  @param[in] stopBits			Stop bits per frame
+ *	@date 05.12.16				first implementation				*/
+inline void usartInitRs232(usartMode_t mode,\
+							usartBaudrate_t baudrate,\
+							usartDataLen_t dataLen,\
+							usartParity_t parity,\
+							usartSBit_t stopBits)
+{
+	// Enable USART module power
+	usartPowerEnable();
+
+	// force USART disabled for setup
+	usartDisable();
+
+	// apply configuration bits
+	usartSetMode(mode);
+	usartSetBaudrate(baudrate);
+	usartSetDataLen(dataLen);
+	usartSetParity(parity);
+	usartSetSBits(stopBits);
+
+	// re-enable USART
+	usartEnable();
+
+	// enable USART interrupts
+	UCSR0B |= (0 << TXCIE0) | (1 << RXCIE0);
+}
+#endif /* USART_RS232_H_ */

--- a/tools/stringtools.c
+++ b/tools/stringtools.c
@@ -1,0 +1,43 @@
+/*
+ * stringtools.c
+ *
+ * Created: 12/11/2016 3:28:43 AM
+ *  Author: inselc
+ */ 
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include "stringtools.h"
+
+/*! @brief Convert byte into Hexadecimal string
+ *
+ *	@param[out] *target			Target string buffer (2 chars)
+ *	@param[in]	source			Source number (byte)
+ *	@return int					String length (2)
+ *	@date 11.12.16				first implementation				*/
+int hexToStr(char* target, uint8_t source)
+{
+	int i;
+	char c;
+	uint8_t n;
+	
+	if (target == NULL)
+	{
+		return -1;
+	}
+
+	for (i = 0; i <= 1; i++)
+	{
+		n = (source >> ((1-i) * 4)) & 0x0F;
+		
+		if (n < 0xA)
+			c = '0' + n;	// 0 ... 9
+		else
+			c = 'A' + (n - 0x0A);	// A ... F
+		
+		target[i] = c;
+	}
+
+	return 2;
+}

--- a/tools/stringtools.h
+++ b/tools/stringtools.h
@@ -1,0 +1,14 @@
+/*
+ * stringtools.h
+ *
+ * Created: 12/11/2016 3:25:46 AM
+ *  Author: inselc
+ */ 
+
+
+#ifndef STRINGTOOLS_H_
+#define STRINGTOOLS_H_
+
+int hexToStr(char* target, uint8_t source);
+
+#endif /* STRINGTOOLS_H_ */


### PR DESCRIPTION
This PR adds basic I/O functionality for GPIO, UART and SPI.

## GPIO
Each hardware I/O pin is represented by a structure `pin_t`, containing all relevant data for each pin - such as the corresponding DDR and PORT registers.

### Pin setup
1. Assign values to all fields of the `pin_t` structure
2. Call `ioInitPin` with the structure containing the pin configuration

### Digital I/O
To read from a digital pin, use `ioReadPin`.
To write a value to a pin, use `ioWritePin`.
To toggle a pin between HIGH and LOW, use `ioTogglePin`.

### Analog I/O
Not yet implemented.

## Serial communication
Serial communication uses interrupts for receiving data, and busy waiting while sending data. Received data is stored in a 64-byte ring buffer. The maximum string length for sending data at one time is limited to 64 bytes, as well.

Data is transmitted and received asynchronously using the 8N1 format.

### Setup
1. Make sure interrupts are disabled
2. Call `serialInit` and provide a baud rate to be used
3. Re-enabled interrupts to receive and transmit data

### Sending data
To send a string literal, use the `serialWriteStr`.
To send data from a buffer, use `serialWriteBuf`. The timeout can be set to -1 for "infinite" timeout.
To check, whether any data was received, use `serialAvailable`. This will return the number of unread bytes in the RX ring buffer.
To read a single byte from the RX ring buffer, use `serialRead`.
To read multiple bytes into a buffer, use `serialReadBuf`. This will read until the buffer is filled, or the RX ring buffer is empty.

## Wiznet W5100 SPI I/O
Basic register access operations for the Wiznet W5100 NIC, which is connected to the MCU via the SPI Bus. The W5100's Chip Select pin is configured as `PORTB2` / Arduino Pin 10.

### Setup
1. Make sure interrupts are disabled
2. Configure SPI using `spiInitMaster`
3. Call `w51eInit`
4. Re-enabled interrupts

### Reading and writing W5100 registers
Read and write operations transfer a single byte at a time. Combine multiple calls to transfer 16 bit values.
To read the value from a W5100 register, use `w51eRead`.
To write a value to a W5100 register, use `w51eWrite`.