### PR TITLE
Fixes non-static inlines; Adds server-mode socket I/O over TCP/IP and system watchdog

### DIFF
--- a/core/Debug/debug.h
+++ b/core/Debug/debug.h
@@ -5,14 +5,21 @@
  *  Author: inselc
  */ 
 
-
 #ifndef DEBUG_H_
 #define DEBUG_H_
 
 #include "../../core/Serial/Serial.h"
+#include <stdlib.h>
 
-#define DEBUG_LOG(x) serialWriteStr("\r\n -- DEBUG . "); \
-					 serialWriteStr(x); \
-					 serialWriteStr(" --\r\n")
+static inline void ERROR_LOG(const char* x) 
+{
+	serialWriteStr("\r\n Error in " __FILE__ ":");
+	char n[4];
+	itoa(__LINE__, n, 10);
+	serialWriteBuf((uint8_t*)n, 4, -1);
+	serialWriteStr(" ");
+	serialWriteStr(x);
+	serialWriteStr("\r\n");
+}
 
 #endif /* DEBUG_H_ */

--- a/core/Ethernet/Ethernet.c
+++ b/core/Ethernet/Ethernet.c
@@ -1,0 +1,263 @@
+/*
+ * Ethernet.c
+ *
+ * Created: 12/13/2016 1:57:27 AM
+ *  Author: inselc
+ */ 
+
+#include <stdbool.h>
+#include <limits.h>
+#include <stdint.h>
+#include "Ethernet.h"
+#include "../Debug/debug.h"
+#include "../../drivers/W5100/W5100.h"
+
+/*! @brief (Re)initialize the W5100 NIC
+ *
+ *  @date 10.04.17			First implementation					*/
+void ethInit(void)
+{
+	// Reset all W5100 registers
+	w51eWrite(W5100_REG_MR, (1 << W5100_MR_RST));
+
+	// Enable socket interrupts 0 through 3
+	w51eWrite(W5100_REG_IMR, (1 << W5100_IM_IR0) | (1 << W5100_IM_IR1) | (1 << W5100_IM_IR2) | (1 << W5100_IM_IR3));
+
+	// Set retry time to 200ms
+	// default value after reset: 0x07D0
+
+	// Set retry count to 8
+	// default value after reset: 0x08
+
+	// Set memory allocation to 2K each
+	// default values after reset: 0x55
+}
+
+/*! @brief Set MAC and IP Addresses of the W5100 NIC
+ *
+ *  @param[in] mac[6]		Hardware MAC Address
+ *	@param[in] subnet[4]	Subnet mask
+ *	@param[in] ip[4]		Local IP Address			
+ *	@date 13.12.16			First implementation					*/
+void ethSetLocalIP(uint8_t mac[6], uint8_t subnet[4], uint8_t ip[4])
+{
+	// Set MAC
+	w51eWrite(W5100_REG_SHAR0, mac[0]);
+	w51eWrite(W5100_REG_SHAR1, mac[1]);
+	w51eWrite(W5100_REG_SHAR2, mac[2]);
+	w51eWrite(W5100_REG_SHAR3, mac[3]);
+	w51eWrite(W5100_REG_SHAR4, mac[4]);
+	w51eWrite(W5100_REG_SHAR5, mac[5]);
+
+	// Set Subnet
+	w51eWrite(W5100_REG_SUBR0, subnet[0]);
+	w51eWrite(W5100_REG_SUBR1, subnet[1]);
+	w51eWrite(W5100_REG_SUBR2, subnet[2]);
+	w51eWrite(W5100_REG_SUBR3, subnet[3]);
+
+	// Set Source IP
+	w51eWrite(W5100_REG_SIPR0, ip[0]);
+	w51eWrite(W5100_REG_SIPR1, ip[1]);
+	w51eWrite(W5100_REG_SIPR2, ip[2]);
+	w51eWrite(W5100_REG_SIPR3, ip[3]);
+}
+
+/*! @brief Open socket
+ *
+ *  @param[in] socket		Target socket
+ *	@param[in] port			Port number
+ *	@param[in] protocol		Socket protocol
+ *	@param[in] modeFlags	Additional mode flags
+ *	@return uint8_t			0 if successful
+ *	@date 10.04.17			First implementation					*/
+uint8_t ethSockOpen(socket_t socket, uint16_t port, uint8_t protocol, uint8_t modeFlags)
+{
+	// Make sure socket is closed, first
+	if (w51eRead(W5100_SRG(socket, W5100_REG_S0_SR)) != W5100_Sn_SR_SOCK_CLOSED)
+	{
+		ethSockClose(socket);
+	}
+
+	// Apply protocol and mode flags
+	w51eWrite(W5100_SRG(socket, W5100_REG_S0_MR), (protocol << W5100_Sn_MR_PROTO) | modeFlags);
+
+	// Set source port number
+	//w51eWrite(W5100_SRG(socket, W5100_REG_S0_PORT0), (port & 0xFF00) >> 8);
+	//w51eWrite(W5100_SRG(socket, W5100_REG_S0_PORT1), (port & 0x00FF));
+	w51eWriteW(W5100_SRG(socket, W5100_REG_S0_PORT0), port);
+
+	// Open socket
+	w51eWrite(W5100_SRG(socket, W5100_REG_S0_CR), W5100_Sn_CR_OPEN);
+
+	// Block until open
+	uint_fast16_t timeoutCounter = 0;
+	while ((timeoutCounter < UINT_FAST16_MAX) && (w51eRead(W5100_SRG(socket, W5100_REG_S0_SR)) == W5100_Sn_SR_SOCK_CLOSED))
+	{
+		++timeoutCounter;
+	}
+
+	// Check if opening timed out or if connection was established
+	if (w51eRead(W5100_SRG(socket, W5100_REG_S0_SR)) == W5100_Sn_SR_SOCK_CLOSED)
+	{	
+		ERROR_LOG("OpenSocket timeout");
+		ethSockClose(socket);
+		return 2;
+	}
+
+	// Socket is now open
+	return 0;
+}
+
+/*! @brief Close socket
+ *
+ *	@param[in] socket		Target socket
+ *	@date 10.04.17			First implementation					*/
+void ethSockClose(socket_t socket)
+{
+	w51eWrite(W5100_SRG(socket, W5100_REG_S0_CR), W5100_Sn_CR_CLOSE);
+}
+
+/*! @brief Set up socket into listening state (Server mode)
+ *
+ *	@param[in] socket		Target socket
+ *	@return uint8_t			0 if successful
+ *	@date 10.04.17			First implementation					*/
+uint8_t ethSockListen(socket_t socket)
+{
+	// LISTEN mode can only be entered in TCP mode after init
+
+	// Check if socket is initialized properly
+	if (w51eRead(W5100_SRG(socket, W5100_REG_S0_SR)) != W5100_Sn_SR_SOCK_INIT)
+	{
+		ERROR_LOG("Sock not in INIT mode");
+		return 2;
+	}
+
+	 // Set socket mode to listen
+	 w51eWrite(W5100_SRG(socket, W5100_REG_S0_CR), W5100_Sn_CR_LISTEN);
+
+	 // Wait until socket is in listen mode;
+	 uint_fast16_t timeoutCounter = 0;
+	 while ((timeoutCounter < UINT_FAST16_MAX) && (w51eRead(W5100_SRG(socket, W5100_REG_S0_SR)) != W5100_Sn_SR_SOCK_LISTEN))
+	 {
+		++timeoutCounter;
+	 }
+
+	 // Check if listen timed out
+	 if (w51eRead(W5100_SRG(socket, W5100_REG_S0_SR)) != W5100_Sn_SR_SOCK_LISTEN)
+	 {
+		ERROR_LOG("Could not set LISTEN mode");
+		return 3;
+	 }
+
+	 // Socket is now in LISTEN mode
+	 return 0;
+}
+
+/*! @brief Disconnect socket connection
+ *
+ *	@param[in] socket		Connected socket
+ *	@date 10.04.17			First implementation					*/
+void ethSockDisconnect(socket_t socket)
+{
+	w51eWrite(W5100_SRG(socket, W5100_REG_S0_CR), W5100_Sn_CR_DISCON);
+}
+
+/*! @brief Check for data waiting to be read
+ *
+ *	@param[in] socket		Target socket
+ *  @return uint16_t		Number of bytes to be read
+ *	@date 11.04.17			First implementation					*/
+uint16_t ethAvailable(socket_t socket)	
+{
+	return w51eReadW(W5100_REG_S0_RX_RSR0);
+	//return ((w51eRead(W5100_SRG(socket, W5100_REG_S0_RX_RSR0)) & 0x00FF) << 8) | w51eRead(W5100_SRG(socket, W5100_REG_S0_RX_RSR1));
+}
+
+/*! @brief Read data from socket receive memory
+ *
+ *  @param[in] socket		Socket to read from
+ *	@param[out] *dataBuffer	Target buffer to store data
+ *	@param[in] bufSize		Buffer size
+ *	@return uint16_t		Number of bytes read
+ *	@date 11.04.17			First implementation					*/
+uint16_t ethRead(socket_t socket, uint8_t* dataBuffer, uint16_t bufSize)
+{
+	// Check if data is available for reading
+	uint16_t bytesAvailable = ethAvailable(socket);
+	if (bytesAvailable == 0)
+	{
+		// Abort, if no data queued
+		return 0;
+	}
+
+	// Get read pointer and mask from device 
+	uint16_t readStart = w51eReadW(W5100_SRG(socket, W5100_REG_S0_RX_RD0)); //((w51eRead(W5100_SRG(socket, W5100_REG_S0_RX_RD0)) & 0x00FF) << 8) | w51eRead(W5100_SRG(socket, W5100_REG_S0_RX_RD1));
+	uint16_t mask = (0x400 << ((w51eRead(W5100_REG_RMSR) & (0x3 << (socket * 2))) >> (socket * 2))) - 1;
+
+	// Cyclic read single byte until all data is processed or buffer limit is reached
+	uint_fast16_t dataCounter = 0;
+	while ((dataCounter < bufSize) && (dataCounter < bytesAvailable))
+	{
+		//dataBuffer[dataCounter] = w51eRead(W5100_CHIP_BASE + W5100_RXM_BASE + (((readStart + dataCounter) % (mask + 1)) & mask));
+		dataBuffer[dataCounter] = w51eRead(W5100_CHIP_BASE + W5100_RXM_BASE + (readStart & mask));
+		++readStart;
+		++dataCounter;
+	}
+
+	// Set up read pointer for next receive operation
+	/*w51eWrite(W5100_SRG(socket, W5100_REG_S0_RX_RD0), (readPtr&0xFF00) >> 8);
+	w51eWrite(W5100_SRG(socket, W5100_REG_S0_RX_RD1), readPtr&0x00FF);*/
+	w51eWriteW(W5100_SRG(socket, W5100_REG_S0_RX_RD0), readStart);
+
+	// Incoming data will now be stored starting at the RXD address
+	w51eWrite(W5100_SRG(socket, W5100_REG_S0_CR), W5100_Sn_CR_RECV);
+
+	return dataCounter;
+}
+
+// ethReadFrom
+
+/*! @brief Write data to socket memory for transmission
+ *
+ *	@param[in] socket		Target socket
+ *	@param[in] *dataBuffer	Buffer to read data from
+ *	@param[in] dataLenght	Number of bytes to be sent
+ *	@return uint16_t		Number of bytes actually written
+ *	@date 14.04.17			First implementation					*/
+uint16_t ethWrite(socket_t socket, uint8_t* dataBuffer, uint16_t dataLength)
+{
+	// Abort if no data to be written
+	if (dataLength == 0)
+	{
+		return 0;
+	}
+
+	// Abort if device transmit memory is full
+	uint16_t freeSize = w51eReadW(W5100_SRG(socket, W5100_REG_S0_TX_FSR0));
+	if (freeSize == 0)
+	{
+		return 0;
+	}
+
+	// Get send pointer and mask from device
+	uint16_t writeStart = w51eReadW(W5100_SRG(socket, W5100_REG_S0_TX_WR0));
+	uint16_t mask = (0x400 << ((w51eRead(W5100_REG_TMSR) & (0x3 << (socket * 2))) >> (socket * 2))) - 1;
+
+	// Cyclic write single byte until all data is processed or buffer limit is reached
+	uint_fast16_t dataCounter = 0;
+	while ((dataCounter < dataLength) && (dataCounter < freeSize))
+	{
+		//w51eWrite(W5100_CHIP_BASE + W5100_TXM_BASE + (((writeStart + dataCounter) % (mask + 1)) & mask), dataBuffer[dataCounter]);
+		w51eWrite(W5100_CHIP_BASE + W5100_TXM_BASE + ((writeStart + dataCounter) & mask), dataBuffer[dataCounter]);
+		++dataCounter;
+	}
+
+	// Set up write pointer for next transmit operation
+	w51eWriteW(W5100_SRG(socket, W5100_REG_S0_TX_WR0), (writeStart + dataCounter));
+
+	// Trigger sending data till new TXR address
+	w51eWrite(W5100_SRG(socket, W5100_REG_S0_CR), W5100_Sn_CR_SEND);
+
+	return dataCounter;
+}

--- a/core/Ethernet/Ethernet.h
+++ b/core/Ethernet/Ethernet.h
@@ -1,0 +1,31 @@
+/*
+ * Ethernet.h
+ *
+ * Created: 12/11/2016 3:21:41 AM
+ *  Author: inselc
+ */ 
+
+#ifndef ETHERNET_H_
+#define ETHERNET_H_
+
+#include <stdint.h>
+
+typedef uint8_t socket_t;
+
+void ethInit(void);
+void ethSetLocalIP(uint8_t mac[6], uint8_t subnet[4], uint8_t ip[4]);
+
+uint8_t ethSockOpen(socket_t socket, uint16_t port, uint8_t protocol, uint8_t modeFlags);
+void ethSockClose(socket_t socket);
+
+uint8_t ethSockListen(socket_t socket);
+uint8_t ethSockConnect(socket_t socket, uint8_t host, uint8_t port);
+void ethSockDisconnect(socket_t socket);
+
+uint16_t ethAvailable(socket_t socket);
+uint16_t ethRead(socket_t socket, uint8_t* dataBuffer, uint16_t bufSize);
+uint16_t ethReadFrom(socket_t socket, uint8_t srcIP[4], uint16_t port, uint8_t* dataBuffer, uint16_t bufSize);
+uint16_t ethWrite(socket_t socket, uint8_t* dataBuffer, uint16_t dataLength);
+uint16_t ethWriteTo(socket_t socket, uint8_t destIP[4], uint16_t port, uint8_t* dataBuffer, uint16_t dataLength);
+
+#endif /* ETHERNET_H_ */

--- a/core/Serial/Serial.c
+++ b/core/Serial/Serial.c
@@ -5,6 +5,7 @@
 
 /*! @file */
 
+#include <avr/interrupt.h>
 #include "Serial.h"
 
 /*! @brief Push data into receive ring buffer
@@ -214,18 +215,6 @@ int serialWriteStr(const char* message)
 	}
 
 	return stringPos;
-}
-
-/*! @brief Output String from FLASH via Serial
- *
- *	@warn Not yet implemented
- *
- *	@param[in] *message			String to be transmitted (\0-Term!)
- *	@return int					Number of chars sent
- *	@date 13.12.16				first implementation				*/
-int serialWriteStrP(const PROGMEM char* message)
-{
-	return 0;
 }
 
 /*! @brief Output via serial from non-progmem memory buffer

--- a/core/Serial/Serial.h
+++ b/core/Serial/Serial.h
@@ -13,8 +13,6 @@
 #include <stddef.h>
 #include <limits.h>
 #include <avr/pgmspace.h>
-#include <avr/interrupt.h>
-
 #include "../../modules/usart/usart_common.h"
 #include "../../modules/usart/usart_rs232.h"
 
@@ -51,7 +49,6 @@ uint8_t serialReadBufUntil(uint8_t* buffer, uint8_t bufSize, char stopChar, int 
 uint8_t serialRead(void);
 uint8_t serialPeek(void);
 int serialWriteStr(const char* message);
-int serialWriteStrP(const PROGMEM char* message);
 uint16_t serialWriteBuf(uint8_t* data, uint16_t length, int timeout);
 void serialFlush(void);
 
@@ -59,7 +56,7 @@ void serialFlush(void);
  *
  *	@param[in] data			Byte to be transmitted
  *	@date 07.12.16			first implementation					*/
-inline void serialWrite(uint8_t data)
+static inline void serialWrite(uint8_t data)
 {
 	usartSendData(data);
 }
@@ -70,7 +67,7 @@ inline void serialWrite(uint8_t data)
  *
  *	@param[in] baudrate		USART Baudrate
  *	@date 07.12.16			first implementation					*/
-inline void serialInit(usartBaudrate_t baudrate)
+static inline void serialInit(usartBaudrate_t baudrate)
 {
 	serialFlush();
 	usartInitRs232(USART_MSTR_ASYNC, baudrate, USART_LEN_8, USART_PARITY_NONE, USART_SBIT_1);

--- a/core/Watchdog/Watchdog.c
+++ b/core/Watchdog/Watchdog.c
@@ -1,0 +1,86 @@
+/*
+ * Watchdog.c
+ *
+ * Created: 4/15/2017 9:48:45 PM
+ *  Author: inselc
+ */ 
+
+#include "Watchdog.h"
+#include <stdint.h>
+#include <stdbool.h>
+#include <avr/io.h>
+#include <avr/interrupt.h>
+#include "../Serial/Serial.h" 
+
+static bool gracefulReset;
+
+/*! @brief Check, whether the system is booting after a reset
+ *		   caused by an error.
+ *
+ *	@return bool			Whether the system was reset due to an
+ *							error.
+ *	@date 15.04.17			First implementation					*/
+
+/*! @brief Set up the system watchdog timer
+ *
+ *	@note The watchdog needs to be reset ("petted") every 120ms,
+ *		  or the system will be reset with an error
+ *
+ *	@date 15.04.17			First implementation					*/
+void wdogInit(void)
+{
+	// Default to error-reset
+	gracefulReset = false;
+	
+	cli();
+	wdt_enable(WDTO_500MS);
+
+	// Interrupt+System Reset Mode
+	WDTCSR |= (1 << WDE) | (1 << WDIE);
+	sei();
+}
+
+/*! @brief Graceful system reboot
+ *
+ *	Holds execution till the watchdog timer times out
+ *
+ *	@date 15.04.17			First implementation					*/
+void __attribute__((noreturn,naked)) wdogReboot(void)
+{
+	gracefulReset = true;
+	
+	while(1)
+	{
+		;
+	}
+}
+
+/*! @brief Watchdog timer interrupt service routine
+ *
+ *	Checks, whether the timeout was intentional, and reboots the
+ *	system.
+ *
+ *	@date 15.04.17			First implementation					*/
+ISR(WDT_vect)
+{
+	cli();
+	if (gracefulReset)
+	{
+		serialWriteStr("Rebooting...\r\n\r\n");
+		; // Save stuff
+	}
+	else
+	{
+		serialWriteStr("Error: Watchdog timeout.\r\n\r\n");
+		; // Display error message
+	}
+
+	// WDT is now in system-reset mode
+	sei();
+	while(1)
+	{
+		// Wait for WDT to trigger reset
+		;
+	}
+}
+

--- a/core/Watchdog/Watchdog.h
+++ b/core/Watchdog/Watchdog.h
@@ -1,0 +1,39 @@
+/*
+ * Watchdog.h
+ *
+ * Created: 4/15/2017 9:48:10 PM
+ *  Author: inselc
+ */ 
+
+
+#ifndef WATCHDOG_H_
+#define WATCHDOG_H_
+
+/*! @file */
+
+#include <avr/wdt.h>
+
+void wdogInit(void);
+void wdogReboot(void);
+
+/*!	@brief Stop any watchdog timer that may be running
+ *
+ *	@note To be used right after system boot to prevent 
+ *		  a reset-loop.
+ *
+ *	@date 15.04.17			First implementation					*/
+static inline __attribute__((__always_inline__)) void wdogStop(void)
+{
+	wdt_disable();
+}
+
+/*! @brief Reset the watchdog timer countdown
+ *
+ *	@date 15.04.17			First implementation					*/
+static inline __attribute__((__always_inline__)) void wdogPet(void)
+{
+	wdt_reset();
+}
+
+
+#endif /* WATCHDOG_H_ */

--- a/drivers/W5100/W5100.h
+++ b/drivers/W5100/W5100.h
@@ -94,6 +94,12 @@
 #define W5100_Sn_SR_SOCK_LAST_ACK 0x1D
 #define W5100_Sn_SR_SOCK_ARP	 0x01
 
+#define W5100_CHIP_BASE 0x0000
+#define W5100_TXM_BASE	0x4000
+#define W5100_TXM_END	0x5FFF
+#define W5100_RXM_BASE	0x6000
+#define W5100_RXM_END	0x7FFF
+
 typedef enum tagW51eReg_t{	
 	/* -- Common registers -- */
 	/* Mode */
@@ -373,9 +379,32 @@ typedef enum tagW51eReg_t{
 	/* reserved 0x072C - 0x07FF */
 } w51eReg_t;
 
+#define W5100_SRG(s,r) ((r) + ((s)<<8))
+
 // Low level Device-specific implementation 
 void w51eInit(void);
 void w51eWrite(w51eReg_t reg, uint8_t data);
 uint8_t w51eRead(w51eReg_t reg);
+
+/*! @brief Read 16-bit data (WORD) from W5100 registers
+ *
+ *	@param[in] reg16		MSB-register of 2-Byte data
+ *	@return uint16_t		Data from registers
+ *	@date 14.04.17			First implementation					*/
+static inline uint16_t w51eReadW(w51eReg_t reg16)
+{
+	return ((w51eRead(reg16) & 0x00FF) << 8) | w51eRead(reg16 + 1);
+}
+
+/*! @brief Write 16-bit data (WORD) to W5100 register
+ *
+ *  @param[in] reg16		W5100 MSB-register
+ *	@param[in] data			Data to be written
+ *	@date 14.04.17			First implementation					*/
+static inline void w51eWriteW(w51eReg_t reg16, uint16_t data)
+{
+	w51eWrite(reg16, (data&0xFF00) >> 8);
+	w51eWrite(reg16+1, data&0x00FF);
+}
 
 #endif /* W5100_H_ */

--- a/modules/io/io.h
+++ b/modules/io/io.h
@@ -10,6 +10,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
+#include <avr/io.h>
 
 #define LOW		false	/*!< Logic LOW pin state representation		*/
 #define HIGH	true	/*!< Logic HIGH pin state representation	*/
@@ -53,7 +54,7 @@ typedef struct tagPin_t
  *  @param[inout] *pin		Selected pin configuration
  *  @param[in] direction	New pin direction (INPUT/OUTPUT)
  *  @date 04.12.16			first implementation					*/
-inline void ioSetPinDirection(pin_t* pin, pinDir_t direction)
+static inline void ioSetPinDirection(pin_t* pin, pinDir_t direction)
 {
 	// update configuration
 	pin->Direction = direction;
@@ -73,7 +74,7 @@ inline void ioSetPinDirection(pin_t* pin, pinDir_t direction)
  *  @param[in] pin			Selected pin
  *	@return bool			Pin state
  *  @date 04.12.16			first implementation					*/
-inline bool ioReadPin(pin_t pin)
+static inline bool ioReadPin(pin_t pin)
 {
 	// return pin state as boolean
 	return (bool)(*pin.Port & (1 << pin.Number));
@@ -84,7 +85,7 @@ inline bool ioReadPin(pin_t pin)
  *	@param[in] pin			Target pin
  *	@param[in] state		Output state
  *	@date 04.12.16			first implementation					*/
-inline void ioWritePin(pin_t pin, bool state)
+static inline void ioWritePin(pin_t pin, bool state)
 {
 	// apply new state to pin output
 	*pin.Port &= ~(!state << pin.Number);
@@ -98,7 +99,7 @@ inline void ioWritePin(pin_t pin, bool state)
  *	@param[inout] pin		Selected pin configuration
  *	@param[in] pullUpEnable	New pullup-disable state
  *	@data 04.12.16			first implementation					*/
-inline void ioSetPinPullup(pin_t* pin, bool pullUpEnable)
+static inline void ioSetPinPullup(pin_t* pin, bool pullUpEnable)
 {
 	// apply pull-up only, if pin direction is an output.
 	if (pin->Direction == INPUT)
@@ -118,7 +119,7 @@ inline void ioSetPinPullup(pin_t* pin, bool pullUpEnable)
  *
  *	@param[in] pinConf		Pin configuration
  *	@date 04.12.16			first implementation					*/
-inline void ioInitPin(pin_t pinConf)
+static inline void ioInitPin(pin_t pinConf)
 {
 	// Set pin direction in DDR
 	ioSetPinDirection(&pinConf, pinConf.Direction);
@@ -130,7 +131,7 @@ inline void ioInitPin(pin_t pinConf)
  *
  *	@param[in] PUDisable	Disable all pull-up resistors
  *	@date 04.12.16			first implementation					*/
-inline void ioSetGlobalPullUp(bool PUDisable)
+static inline void ioSetGlobalPullUp(bool PUDisable)
 {
 	MCUCR &= ~(PUDisable << PUD);
 	MCUCR |= !PUDisable << PUD;
@@ -142,7 +143,7 @@ inline void ioSetGlobalPullUp(bool PUDisable)
  * 
  *	@param[in] pin			Target pin
  *	@date 04.12.16			first implementation					*/
-inline void ioTogglePin(pin_t pin)
+static inline void ioTogglePin(pin_t pin)
 {
 	//if ( (*pin.DDR & (1 << pin.Number)) && (pin.Direction == OUTPUT) )
 	{

--- a/modules/spi/spi_common.h
+++ b/modules/spi/spi_common.h
@@ -41,7 +41,7 @@ typedef enum tagSpiClkMode_t
 /*! @brief Enable SPI module power
  *
  *	@date 04.12.16			first implementation					*/
-inline void spiPowerEnable(void)
+static inline void spiPowerEnable(void)
 {
 	// Enable SPI module in the power reduction register as per
 	// datasheet p. 215 (23.2 Overview)
@@ -51,7 +51,7 @@ inline void spiPowerEnable(void)
 /*! @brief Disable SPI module power
  *
  *	@date 04.12.16			first implementation					*/
-inline void spiPowerDisable(void)
+static inline void spiPowerDisable(void)
 {
 	// Disable SPI module in the power reduction register as per
 	// datasheet p. 215 (23.2 Overview)
@@ -61,7 +61,7 @@ inline void spiPowerDisable(void)
 /*! @brief Enable SPI function
  *
  *	@date 05.12.16			first implementation					*/
-inline void spiEnable(void)
+static inline void spiEnable(void)
 {
 	SPCR |= 1 << SPE;
 }
@@ -69,7 +69,7 @@ inline void spiEnable(void)
 /*! @brief Disable SPI function
  *
  *	@date 05.12.16			first implementation					*/
-inline void spiDisable(void)
+static inline void spiDisable(void)
 {
 	SPCR &= ~(1 << SPE);
 }
@@ -78,7 +78,7 @@ inline void spiDisable(void)
  *
  *	@param[in] mode			Slave/Master mode
  *	@date 05.12.16			first implementation					*/
-inline void spiSetMstrSlave(spiMode_t mode)
+static inline void spiSetMstrSlave(spiMode_t mode)
 {
 	// Set/Clear SPI master mode in SPCR as per datasheet 
 	// p. 221 (23.5.1 SPI Control Register 0)
@@ -92,7 +92,7 @@ inline void spiSetMstrSlave(spiMode_t mode)
  *
  *	@param[in] mode			SPI Mode (0...3)
  *	@date 05.12.16			first implementation					*/
-inline void spiSetClkMode(spiClkMode_t mode)
+static inline void spiSetClkMode(spiClkMode_t mode)
 {
 	// Set/Clear SPI clock polarity and phase as per datasheet
 	// p. 221f (23.5.1 SPI Control Register 0)
@@ -104,7 +104,7 @@ inline void spiSetClkMode(spiClkMode_t mode)
  *
  *	@param[in] order		Data direction LSB or MSB first
  *	@date 05.12.16			first implementation					*/
-inline void spiSetDataOrder(spiDataOrder_t order)
+static inline void spiSetDataOrder(spiDataOrder_t order)
 {
 	SPCR &= ~(!order << DORD);
 	SPCR |= order << DORD;
@@ -113,7 +113,7 @@ inline void spiSetDataOrder(spiDataOrder_t order)
 /*! @brief Get SPI interrupt flag state
  *
  *	@date 05.12.16			first implementation					*/
-inline bool spiGetIF(void)
+static inline bool spiGetIF(void)
 {
 	// Get interrupt flag state
 	// see datasheet p. 223 (25.3.2 SPI Status Register 0)
@@ -127,7 +127,7 @@ inline bool spiGetIF(void)
  *  SPDR (see datasheet p. 223, 23.5.2 SPI Status Register 0).
  *
  *	@date 05.12.16			first implementation					*/
-inline void spiClrIF(void)
+static inline void spiClrIF(void)
 {
 	// Clear interrupt flag
 	SPSR &= (1 << SPIF);
@@ -137,7 +137,7 @@ inline void spiClrIF(void)
  *
  *	@param[in] data			Byte to be transmitted
  *	@date 05.12.16			first implementation					*/
-inline void spiTxByte(uint8_t data)
+static inline void spiTxByte(uint8_t data)
 {
 	SPDR = data;
 }
@@ -146,7 +146,7 @@ inline void spiTxByte(uint8_t data)
  *
  *	@param[in] data			Byte to be transmitted
  *	@date 07.12.16			first implementation					*/
-inline void spiTxByteWait(uint8_t data)
+static inline void spiTxByteWait(uint8_t data)
 {
 	spiTxByte(data);
 
@@ -157,7 +157,7 @@ inline void spiTxByteWait(uint8_t data)
  *
  *	@return	uint8_t			Data from SPI data register (SPDR)
  *	@date 05.12.16			first implementation					*/
-inline uint8_t spiRxByte(void)
+static inline uint8_t spiRxByte(void)
 {
 	return SPDR;
 }
@@ -169,7 +169,7 @@ inline uint8_t spiRxByte(void)
  *
  *	@return uint8_t			Data from SPI data register (SPDR)
  *	@date 05.12.16			first implementation					*/
-inline uint8_t spiWaitRxByte(void)
+static inline uint8_t spiWaitRxByte(void)
 {
 	// Poll SPIF until set
 	while(!spiGetIF()){;}
@@ -177,7 +177,7 @@ inline uint8_t spiWaitRxByte(void)
 	return spiRxByte();
 }
 
-inline uint8_t spiTransfer(uint8_t data)
+static inline uint8_t spiTransfer(uint8_t data)
 {
 	SPDR = data;
 	while (!(SPSR & (1 << SPIF))){;}

--- a/modules/spi/spi_master.h
+++ b/modules/spi/spi_master.h
@@ -27,7 +27,7 @@ typedef enum tagSpiClkRate_t
  *
  *	@param[in] rate			SPI Clock rate
  *	@date 05.12.16			first implementation					*/
-inline void spiSetMstrClkRate(spiClkRate_t rate)
+static inline void spiSetMstrClkRate(spiClkRate_t rate)
 {
 	// SPI Double Speed bit
 	SPSR &= ~((((~rate)&0x04) >> 2) << SPI2X);

--- a/modules/usart/usart_common.h
+++ b/modules/usart/usart_common.h
@@ -60,7 +60,7 @@ typedef enum tagUsartBaudrate_t {
  *	See datasheet p. 225 (24.2 Overview).
  *
  *	@date 05.12.16				first implementation				*/
-inline void usartPowerEnable(void)
+static inline void usartPowerEnable(void)
 {
 	PRR &= ~(1 << PRUSART0);
 }
@@ -70,7 +70,7 @@ inline void usartPowerEnable(void)
  *	See datasheet p. 225 (24.2 Overview).
  *
  *	@date 05.12.16				first implementation				*/
-inline void usartPowerDisable(void)
+static inline void usartPowerDisable(void)
 {
 	PRR |= 1 << PRUSART0;
 }
@@ -81,7 +81,7 @@ inline void usartPowerDisable(void)
  *
  *	@param[in] mode				USART mode
  *	@date 05.12.16				first implementation				*/
-inline void usartSetMode(usartMode_t mode)
+static inline void usartSetMode(usartMode_t mode)
 {
 	UCSR0C &= ~(~(mode&0x03) << UPM00);
 	UCSR0C |= (mode&0x03) << UPM00;
@@ -94,7 +94,7 @@ inline void usartSetMode(usartMode_t mode)
  *
  *	@param[in] baudrate			USART baud rate (from enum)
  *	@date 05.12.16				first implementation				*/
-inline void usartSetBaudrate(usartBaudrate_t baudrate)
+static inline void usartSetBaudrate(usartBaudrate_t baudrate)
 {
 	UBRR0 = baudrate & 0x0FFF;
 
@@ -105,7 +105,7 @@ inline void usartSetBaudrate(usartBaudrate_t baudrate)
 /*! @brief Wait until the USART data buffer is empty
  *
  *	@date 05.12.16				first implementation				*/
-inline void usartWaitDREmpty(void)
+static inline void usartWaitDREmpty(void)
 {
 	while( !(UCSR0A & (1 << UDRE0)) ){;}
 }
@@ -113,7 +113,7 @@ inline void usartWaitDREmpty(void)
 /*! @brief Enable USART RTX function
  *
  *	@date 05.12.16				first implementation				*/
-inline void usartEnable(void)
+static inline void usartEnable(void)
 {
 	UCSR0B |= (1 << TXEN0) | (1 << RXEN0);
 }
@@ -121,7 +121,7 @@ inline void usartEnable(void)
 /*! @brief Disable USART RTX function
  *
  *	@date 05.12.16				first implementation				*/
-inline void usartDisable(void)
+static inline void usartDisable(void)
 {
 	UCSR0B &= ~((1 << TXEN0) | (1 << RXEN0));
 }
@@ -130,7 +130,7 @@ inline void usartDisable(void)
  *
  *	@param[in] data				Data to be transmitted
  *	@date 05.12.16				first implementation				*/
-inline void usartSendData(uint16_t data)
+static inline void usartSendData(uint16_t data)
 {
 	//usartWaitDREmpty();
 	UCSR0B &= ~(1 << TXB80);
@@ -142,7 +142,7 @@ inline void usartSendData(uint16_t data)
  *
  *  @return uint16_t			Data from RX buffer
  *	@date 06.12.16				first implementation				*/
-inline uint16_t usartReadData9(void)
+static inline uint16_t usartReadData9(void)
 {
 	return (UDR0) | (((UCSR0B & (1 << TXB80)) >> TXB80) << 8);
 }
@@ -151,7 +151,7 @@ inline uint16_t usartReadData9(void)
  *
  *	@return uint8_t				Data from RX buffer
  *	@date 06.12.16				first implementation				*/
-inline uint8_t usartReadData(void)
+static inline uint8_t usartReadData(void)
 {
 	return UDR0;
 }
@@ -160,7 +160,7 @@ inline uint8_t usartReadData(void)
  *
  *	@return bool				TXC bit state
  *	@date 07.12.16				first implementation				*/
-inline bool usartTXC(void)
+static inline bool usartTXC(void)
 {
 	return (UCSR0A & (1 << TXC0));
 }
@@ -169,7 +169,7 @@ inline bool usartTXC(void)
  *
  *	@return bool				RXC bit state
  *	@date 07.12.16				first implementation				*/
-inline bool usartRXC(void)
+static inline bool usartRXC(void)
 {
 	return (UCSR0A & (1 << RXC0));
 }
@@ -178,7 +178,7 @@ inline bool usartRXC(void)
  *
  *	@return bool				UDRE bit state
  *	@date 07.12.16				first implementation				*/
-inline bool usartUDRE(void)
+static inline bool usartUDRE(void)
 {
 	return (UCSR0A & (1 << UDRE0));
 }

--- a/modules/usart/usart_rs232.h
+++ b/modules/usart/usart_rs232.h
@@ -44,7 +44,7 @@ typedef enum tagUsartSBit_t
  *
  *  @param[in] dataLen			Data length
  *	@date 05.12.16				first implementation				*/
-inline void usartSetDataLen(usartDataLen_t dataLen)
+static inline void usartSetDataLen(usartDataLen_t dataLen)
 {
 	UCSR0B &= ~((((~dataLen)&0x04) >> 2) << UCSZ02);
 	UCSR0C &= ~(((~dataLen)&0x03) << UCSZ00);
@@ -58,7 +58,7 @@ inline void usartSetDataLen(usartDataLen_t dataLen)
  *
  *	@param[in] parity			Parity bit mode
  *	@date 05.12.16				first implementation				*/
-inline void usartSetParity(usartParity_t parity)
+static inline void usartSetParity(usartParity_t parity)
 {
 	UCSR0C &= ~(((~parity)&0x03) << UPM00);
 	UCSR0C |= (parity&0x03) << UPM00;
@@ -70,7 +70,7 @@ inline void usartSetParity(usartParity_t parity)
  *
  *	@param[in] stopBits			Stop bit configuration
  *	@date 05.12.16				first implementation				*/
-inline void usartSetSBits(usartSBit_t stopBits)
+static inline void usartSetSBits(usartSBit_t stopBits)
 {	
 	UCSR0C &= ~(!stopBits << USBS0);
 	UCSR0C |= stopBits << USBS0;
@@ -84,7 +84,7 @@ inline void usartSetSBits(usartSBit_t stopBits)
  *	@param[in] parity			Parity mode (none, even, odd)
  *  @param[in] stopBits			Stop bits per frame
  *	@date 05.12.16				first implementation				*/
-inline void usartInitRs232(usartMode_t mode,\
+static inline void usartInitRs232(usartMode_t mode,\
 							usartBaudrate_t baudrate,\
 							usartDataLen_t dataLen,\
 							usartParity_t parity,\


### PR DESCRIPTION
This PR fixes inline functions not being designated as "static". This allows for better optimisation by the compiler.
This PR also adds basic socket I/O for data transfer over TCP/IP.

## Socket I/O
The NIC features 4 independent sockets, sharing one 8K/8K RX/TX memory.

### Pre-setup
1. Make sure the W5100 SPI is initialised by calling `w51eInit` while interrupts are disabled
2. Enable interrupts
3. Call `ethInit` to (re)initialize the NIC
4. Set the MAC address, a static IP and submask using `ethSetLocalIP`.

### Setup
1. Initialize a `socket_t` variable with the target hardware socket number (0...3).
2. Call `ethSockOpen` with the socket, port number and protocol ID (currently TCP/IP only) to open the socket. If this step fails, `ethSockOpen` will return a non-zero value.

### Accepting connections to a socket (listening)
To set a socket into listening mode, use `ethSockListen`. It will return a non-zero value, if this step fails.

### Reading and writing data
Before reading/writing, check whether the socket is in the `SOCK_ESTABLISHED` state.
To get the number of available bytes in the socket's RX memory, use `ethAvailable`.
To read data from the socket's RX memory, use `ethRead`.
To queue data for transmission, use `ethWrite`.
To disconnect the socket after transmission, use `ethSockDisconnect`. This will put the socket into the `SOCK_CLOSED` state. In order to accept new connections, the socket must be put into listening mode again by using `ethSockListen`.

## Watchdog
The system watchdog will reset the system when the watchdog timer overflows. To prevent a reset in normal operation, the timer must be reset periodically (T<500ms) using `wdogPet`. A system reboot can also be initiated by using `wdogReboot`, which will intentionally let the watchdog time out.