### PR TITLE
Adds UDP, TCP client; Fixes I/O methods; Moves debug strings to PROGMEM

### DIFF
--- a/core/Debug/debug.h
+++ b/core/Debug/debug.h
@@ -10,16 +10,18 @@
 
 #include "../../core/Serial/Serial.h"
 #include <stdlib.h>
+#include <avr/pgmspace.h>
 
-static inline void ERROR_LOG(const char* x) 
+static inline void ERROR_LOG(PGM_P x) 
 {
-	serialWriteStr("\r\n Error in " __FILE__ ":");
+	/*serialWriteStrP(PSTR("\r\n Error in " __FILE__ ":"));
 	char n[4];
 	itoa(__LINE__, n, 10);
 	serialWriteBuf((uint8_t*)n, 4, -1);
-	serialWriteStr(" ");
-	serialWriteStr(x);
-	serialWriteStr("\r\n");
+	serialWriteStrP(PSTR(" "));
+	serialWriteStrP(x);
+	serialWriteStrP(PSTR("\r\n"));*/
+	;
 }
 
 #endif /* DEBUG_H_ */

--- a/core/Ethernet/Ethernet.c
+++ b/core/Ethernet/Ethernet.c
@@ -1,9 +1,12 @@
-/*
- * Ethernet.c
+/*! @brief Data exchange over Ethernet
  *
- * Created: 12/13/2016 1:57:27 AM
- *  Author: inselc
- */ 
+ *	@author inselc
+ *	@date 13.12.16			Initial version
+ *	@date 10.04.17			Added socket ops, tcp r/w				
+ *	@date 18.04.17			Added UDP read
+ *	@date 22.04.17			Calculate memory base addresses
+ *	@date 23.04.17			Changed uint16 to bool/int return type
+ *	@date 23.04.17			Added UDP data write, TCP client		*/
 
 #include <stdbool.h>
 #include <limits.h>
@@ -12,10 +15,56 @@
 #include "../Debug/debug.h"
 #include "../../drivers/W5100/W5100.h"
 
+#define UDP_HEADER_LEN		8
+
+static uint8_t ethSubnetBackup[4];
+
+/*! @brief Utility function to determine the RX/TX memory size
+ *         of a socket
+ *
+ *	@note Only to be used within Ethernet.c
+ * 
+ *	@param[in] socket		Target socket
+ *	@param[in] msr			RMSR or TMSR
+ *	@return uint16_t		RX/TX memory size of socket	
+ *	@date 22.04.17			First implementation					*/
+static uint16_t ethSockGetMemSize(socket_t socket, w51eReg_t msr)
+{
+	return 0x400 << ((w51eRead(msr) & (0x3 << (socket * 2))) >> (socket * 2));
+}
+
+/*!	@brief Utility function to determine RX/TX memory base address
+ *
+ *	@note Only to be used within Ethernet.c
+ *
+ *	@param[in] socket		Target socket
+ *	@param[in] msr			RMSR or TMSR
+ *	@param[in] memBase		Memory base address
+ *	@return uint16_t		RX/TX memory base address for socket
+ *	@date 22.04.17			First implementation					*/
+static uint16_t ethSockGetMemBaseAddr(socket_t socket, w51eReg_t msr)
+{
+	uint_fast16_t memBase;
+	if (msr == W5100_REG_RMSR)
+		memBase = W5100_CHIP_BASE + W5100_RXM_BASE;
+	else
+		memBase = W5100_CHIP_BASE + W5100_TXM_BASE;
+	
+	for(; socket>0; --socket)
+	{
+		memBase += ethSockGetMemSize(socket-1, msr);
+	}
+
+	return memBase;			
+}
+
 /*! @brief (Re)initialize the W5100 NIC
  *
- *  @date 10.04.17			First implementation					*/
-void ethInit(void)
+ *	@param[in] txMemSizes	TX Memory size config (TMSR)
+ *	@param[in] rxMemSizes	RX Memory size config (RMSR)
+ *  @date 10.04.17			First implementation
+ *	@date 23.04.17			Custom memory sizes						*/
+void ethInit(uint8_t txMemSizes, uint8_t rxMemSizes)
 {
 	// Reset all W5100 registers
 	w51eWrite(W5100_REG_MR, (1 << W5100_MR_RST));
@@ -29,8 +78,9 @@ void ethInit(void)
 	// Set retry count to 8
 	// default value after reset: 0x08
 
-	// Set memory allocation to 2K each
-	// default values after reset: 0x55
+	// Set memory allocation
+	w51eWrite(W5100_REG_TMSR, txMemSizes);
+	w51eWrite(W5100_REG_RMSR, rxMemSizes);
 }
 
 /*! @brief Set MAC and IP Addresses of the W5100 NIC
@@ -38,7 +88,8 @@ void ethInit(void)
  *  @param[in] mac[6]		Hardware MAC Address
  *	@param[in] subnet[4]	Subnet mask
  *	@param[in] ip[4]		Local IP Address			
- *	@date 13.12.16			First implementation					*/
+ *	@date 13.12.16			First implementation
+ *	@date 23.04.17			Back up subnet mask in RAM				*/
 void ethSetLocalIP(uint8_t mac[6], uint8_t subnet[4], uint8_t ip[4])
 {
 	// Set MAC
@@ -55,6 +106,11 @@ void ethSetLocalIP(uint8_t mac[6], uint8_t subnet[4], uint8_t ip[4])
 	w51eWrite(W5100_REG_SUBR2, subnet[2]);
 	w51eWrite(W5100_REG_SUBR3, subnet[3]);
 
+	ethSubnetBackup[0] = subnet[0];
+	ethSubnetBackup[1] = subnet[1];
+	ethSubnetBackup[2] = subnet[2];
+	ethSubnetBackup[3] = subnet[3];
+
 	// Set Source IP
 	w51eWrite(W5100_REG_SIPR0, ip[0]);
 	w51eWrite(W5100_REG_SIPR1, ip[1]);
@@ -68,9 +124,10 @@ void ethSetLocalIP(uint8_t mac[6], uint8_t subnet[4], uint8_t ip[4])
  *	@param[in] port			Port number
  *	@param[in] protocol		Socket protocol
  *	@param[in] modeFlags	Additional mode flags
- *	@return uint8_t			0 if successful
- *	@date 10.04.17			First implementation					*/
-uint8_t ethSockOpen(socket_t socket, uint16_t port, uint8_t protocol, uint8_t modeFlags)
+ *	@return bool			true if successful
+ *	@date 10.04.17			First implementation
+ *	@date 23.04.17			Bool return type					*/
+bool ethSockOpen(socket_t socket, uint16_t port, uint8_t protocol, uint8_t modeFlags)
 {
 	// Make sure socket is closed, first
 	if (w51eRead(W5100_SRG(socket, W5100_REG_S0_SR)) != W5100_Sn_SR_SOCK_CLOSED)
@@ -82,8 +139,6 @@ uint8_t ethSockOpen(socket_t socket, uint16_t port, uint8_t protocol, uint8_t mo
 	w51eWrite(W5100_SRG(socket, W5100_REG_S0_MR), (protocol << W5100_Sn_MR_PROTO) | modeFlags);
 
 	// Set source port number
-	//w51eWrite(W5100_SRG(socket, W5100_REG_S0_PORT0), (port & 0xFF00) >> 8);
-	//w51eWrite(W5100_SRG(socket, W5100_REG_S0_PORT1), (port & 0x00FF));
 	w51eWriteW(W5100_SRG(socket, W5100_REG_S0_PORT0), port);
 
 	// Open socket
@@ -101,11 +156,11 @@ uint8_t ethSockOpen(socket_t socket, uint16_t port, uint8_t protocol, uint8_t mo
 	{	
 		ERROR_LOG("OpenSocket timeout");
 		ethSockClose(socket);
-		return 2;
+		return false;
 	}
 
 	// Socket is now open
-	return 0;
+	return true;
 }
 
 /*! @brief Close socket
@@ -120,17 +175,17 @@ void ethSockClose(socket_t socket)
 /*! @brief Set up socket into listening state (Server mode)
  *
  *	@param[in] socket		Target socket
- *	@return uint8_t			0 if successful
- *	@date 10.04.17			First implementation					*/
-uint8_t ethSockListen(socket_t socket)
+ *	@return bool			true if successful
+ *	@date 10.04.17			First implementation
+ *	@date 23.04.17			Bool return type						*/
+bool ethSockListen(socket_t socket)
 {
 	// LISTEN mode can only be entered in TCP mode after init
-
 	// Check if socket is initialized properly
 	if (w51eRead(W5100_SRG(socket, W5100_REG_S0_SR)) != W5100_Sn_SR_SOCK_INIT)
 	{
 		ERROR_LOG("Sock not in INIT mode");
-		return 2;
+		return false;
 	}
 
 	 // Set socket mode to listen
@@ -147,11 +202,50 @@ uint8_t ethSockListen(socket_t socket)
 	 if (w51eRead(W5100_SRG(socket, W5100_REG_S0_SR)) != W5100_Sn_SR_SOCK_LISTEN)
 	 {
 		ERROR_LOG("Could not set LISTEN mode");
-		return 3;
+		return false;
 	 }
 
 	 // Socket is now in LISTEN mode
-	 return 0;
+	 return true;
+}
+
+/*! @brief Connect socket to target in TCP/IP mode
+ *	
+ *	@param[in] socket		Socket to connect from
+ *	@param[in] *targetPeer	Destination to connect to
+ *	@return book			true if connection established
+ *	@date 23.04.17			First implementation					*/
+bool ethSockConnect(socket_t socket, peer_t* targetPeer)
+{
+	// Check if socket is initialized properly
+	if (w51eRead(W5100_SRG(socket, W5100_REG_S0_SR)) != W5100_Sn_SR_SOCK_INIT)
+	{
+		ERROR_LOG("Sock not in INIT mode");
+		return false;
+	}
+
+	// Set destination IP address
+	w51eWrite(W5100_SRG(socket, W5100_REG_S0_DIPR0), targetPeer->ip[0]);
+	w51eWrite(W5100_SRG(socket, W5100_REG_S0_DIPR1), targetPeer->ip[1]);
+	w51eWrite(W5100_SRG(socket, W5100_REG_S0_DIPR2), targetPeer->ip[2]);
+	w51eWrite(W5100_SRG(socket, W5100_REG_S0_DIPR3), targetPeer->ip[3]);
+
+	// Set destination port
+	w51eWriteW(W5100_SRG(socket, W5100_REG_S0_DPORT0), targetPeer->port);
+
+	// Send CONNECT command
+	w51eWriteW(W5100_SRG(socket, W5100_REG_S0_CR), W5100_Sn_CR_CONNECT);
+
+	// Wait for established connection
+	while (w51eRead(W5100_SRG(socket, W5100_REG_S0_SR)) != W5100_Sn_SR_SOCK_ESTABLISHED)
+	{
+		if (w51eRead(W5100_SRG(socket, W5100_REG_S0_IR)) == W5100_Sn_IR_TIMEOUT)
+		{
+			return false;
+		}
+	}
+
+	return true;
 }
 
 /*! @brief Disconnect socket connection
@@ -166,12 +260,12 @@ void ethSockDisconnect(socket_t socket)
 /*! @brief Check for data waiting to be read
  *
  *	@param[in] socket		Target socket
- *  @return uint16_t		Number of bytes to be read
- *	@date 11.04.17			First implementation					*/
-uint16_t ethAvailable(socket_t socket)	
+ *  @return int				Number of bytes to be read
+ *	@date 11.04.17			First implementation
+ *	@date 23.04.17			int return type							*/
+int ethAvailable(socket_t socket)	
 {
 	return w51eReadW(W5100_REG_S0_RX_RSR0);
-	//return ((w51eRead(W5100_SRG(socket, W5100_REG_S0_RX_RSR0)) & 0x00FF) << 8) | w51eRead(W5100_SRG(socket, W5100_REG_S0_RX_RSR1));
 }
 
 /*! @brief Read data from socket receive memory
@@ -179,9 +273,11 @@ uint16_t ethAvailable(socket_t socket)
  *  @param[in] socket		Socket to read from
  *	@param[out] *dataBuffer	Target buffer to store data
  *	@param[in] bufSize		Buffer size
- *	@return uint16_t		Number of bytes read
- *	@date 11.04.17			First implementation					*/
-uint16_t ethRead(socket_t socket, uint8_t* dataBuffer, uint16_t bufSize)
+ *	@return int				Number of bytes read
+ *	@date 11.04.17			First implementation
+ *	@date 22.04.17			Use getMemSize and getBaseAddr
+ *	@date 23.04.17			int return type							*/
+int ethRead(socket_t socket, uint8_t* dataBuffer, int bufSize)
 {
 	// Check if data is available for reading
 	uint16_t bytesAvailable = ethAvailable(socket);
@@ -192,22 +288,20 @@ uint16_t ethRead(socket_t socket, uint8_t* dataBuffer, uint16_t bufSize)
 	}
 
 	// Get read pointer and mask from device 
-	uint16_t readStart = w51eReadW(W5100_SRG(socket, W5100_REG_S0_RX_RD0)); //((w51eRead(W5100_SRG(socket, W5100_REG_S0_RX_RD0)) & 0x00FF) << 8) | w51eRead(W5100_SRG(socket, W5100_REG_S0_RX_RD1));
-	uint16_t mask = (0x400 << ((w51eRead(W5100_REG_RMSR) & (0x3 << (socket * 2))) >> (socket * 2))) - 1;
+	uint16_t readStart = w51eReadW(W5100_SRG(socket, W5100_REG_S0_RX_RD0));
+	uint16_t mask = ethSockGetMemSize(socket, W5100_REG_RMSR) - 1;
+	uint16_t baseAddr = ethSockGetMemBaseAddr(socket, W5100_REG_RMSR);
 
 	// Cyclic read single byte until all data is processed or buffer limit is reached
 	uint_fast16_t dataCounter = 0;
 	while ((dataCounter < bufSize) && (dataCounter < bytesAvailable))
 	{
-		//dataBuffer[dataCounter] = w51eRead(W5100_CHIP_BASE + W5100_RXM_BASE + (((readStart + dataCounter) % (mask + 1)) & mask));
-		dataBuffer[dataCounter] = w51eRead(W5100_CHIP_BASE + W5100_RXM_BASE + (readStart & mask));
+		dataBuffer[dataCounter] = w51eRead(baseAddr + (readStart & mask));
 		++readStart;
 		++dataCounter;
 	}
 
 	// Set up read pointer for next receive operation
-	/*w51eWrite(W5100_SRG(socket, W5100_REG_S0_RX_RD0), (readPtr&0xFF00) >> 8);
-	w51eWrite(W5100_SRG(socket, W5100_REG_S0_RX_RD1), readPtr&0x00FF);*/
 	w51eWriteW(W5100_SRG(socket, W5100_REG_S0_RX_RD0), readStart);
 
 	// Incoming data will now be stored starting at the RXD address
@@ -216,16 +310,116 @@ uint16_t ethRead(socket_t socket, uint8_t* dataBuffer, uint16_t bufSize)
 	return dataCounter;
 }
 
-// ethReadFrom
+/*!	@brief Read data from non TCP/IP socket
+ *
+ *	@note Currently UDP-only.
+ *
+ *	@param[in] socket		Socket to read from
+ *	@param[out] *sourcePeer	Sender info
+ *	@param[out]	*dataBuffer	Target buffer to store data in
+ *	@param[in] bufSize		Maximum data buffer size
+ *	@return int				Number of bytes read, or -1 on error
+ *	@date 23.04.17			First implementation					*/
+int ethReadFrom(socket_t socket, peer_t* sourcePeer, uint8_t* dataBuffer, int bufSize)
+{
+	// Minimum of 8 header bytes
+	uint16_t bytesAvailable = ethAvailable(socket);
+	if (bytesAvailable < 8)
+	{
+		return 0;
+	}
+
+	// Get device memory addresses
+	uint16_t readStart = w51eReadW(W5100_SRG(socket, W5100_REG_S0_RX_RD0));
+	uint16_t mask = ethSockGetMemSize(socket, W5100_REG_RMSR) - 1;
+	uint16_t baseAddr = ethSockGetMemBaseAddr(socket, W5100_REG_RMSR);
+
+	// Setup data and frame counters
+	uint_fast16_t dataCounter = 0;
+	uint_fast16_t frameLen;
+
+	// Fetch header data
+	switch (w51eRead(W5100_SRG(socket, W5100_REG_S0_MR)) & 0x07)
+	{
+		case W5100_Sn_MR_PROTO_UDP:
+		{ 
+			// Read UDP header
+			uint8_t header[UDP_HEADER_LEN];
+			while (dataCounter < UDP_HEADER_LEN)
+			{
+				header[dataCounter] = w51eRead(baseAddr + (readStart & mask));
+				++readStart;
+				++dataCounter;
+			}
+
+			// Extract Peer IP and port from header
+			// as per W5100 datasheet 5.2.2 UDP (p.52)
+			sourcePeer->ip[0] = header[0];
+			sourcePeer->ip[1] = header[1];
+			sourcePeer->ip[2] = header[2];
+			sourcePeer->ip[3] = header[3];
+			sourcePeer->port = (header[4] << 8) | header[5];
+
+			// Extract data frame length from header
+			frameLen = (header[6] << 8) | header[7];
+		}
+		break;
+		/*case W5100_Sn_MR_PROTO_IPRAW:
+		{
+			uint8_t header[IPRAW_HEADER_LEN];
+			while (dataCounter < IPRAW_HEADER_LEN)
+			{
+				header[dataCounter] = w51eRead(W5100_CHIP_BASE + W5100_RXM_BASE + (readStart & mask));
+				++readStart;
+				++dataCounter;
+			}
+
+			// Extract peer IP from header
+			// as per W5100 datasheet 5.2.3 IPRAW (p.58)
+			sourcePeer->ip[0] = header[0];
+			sourcePeer->ip[1] = header[1];
+			sourcePeer->ip[2] = header[2];
+			sourcePeer->ip[3] = header[3];
+
+			// Extract frame length
+			frameLen = (header[4] << 8) | header[5];
+		}
+		break;*/
+		default:
+			// IPRAW / PPPoE / MACRAW not supported
+			frameLen = 0;
+	}
+
+	// Calculate address of last data byte
+	uint16_t readEnd = readStart + frameLen;
+
+	// Read frame data
+	dataCounter = 0;
+	while ((dataCounter < frameLen) && (dataCounter < bufSize) && (dataCounter < (bytesAvailable - 8)))
+	{
+		dataBuffer[dataCounter] = w51eRead(baseAddr + (readStart & mask));
+		++readStart;
+		++dataCounter;
+	}
+
+	// Set up read pointer for next receive operation, skip remaining data
+	w51eWriteW(W5100_SRG(socket, W5100_REG_S0_RX_RD0), readEnd);
+
+	// Incoming data will now be stored starting at the RXD address
+	w51eWrite(W5100_SRG(socket, W5100_REG_S0_CR), W5100_Sn_CR_RECV);
+
+	return dataCounter;
+}
 
 /*! @brief Write data to socket memory for transmission
  *
  *	@param[in] socket		Target socket
  *	@param[in] *dataBuffer	Buffer to read data from
  *	@param[in] dataLenght	Number of bytes to be sent
- *	@return uint16_t		Number of bytes actually written
- *	@date 14.04.17			First implementation					*/
-uint16_t ethWrite(socket_t socket, uint8_t* dataBuffer, uint16_t dataLength)
+ *	@return int				Number of bytes actually written
+ *	@date 14.04.17			First implementation					
+ *	@date 22.04.17			Use getMemSize and getBaseAddr			*/
+int ethWrite(socket_t socket, uint8_t* dataBuffer, int dataLength)
 {
 	// Abort if no data to be written
 	if (dataLength == 0)
@@ -234,22 +428,23 @@ uint16_t ethWrite(socket_t socket, uint8_t* dataBuffer, uint16_t dataLength)
 	}
 
 	// Abort if device transmit memory is full
-	uint16_t freeSize = w51eReadW(W5100_SRG(socket, W5100_REG_S0_TX_FSR0));
+	int freeSize = w51eReadW(W5100_SRG(socket, W5100_REG_S0_TX_FSR0));
 	if (freeSize == 0)
 	{
+		ERROR_LOG("TXM full");
 		return 0;
 	}
 
 	// Get send pointer and mask from device
 	uint16_t writeStart = w51eReadW(W5100_SRG(socket, W5100_REG_S0_TX_WR0));
-	uint16_t mask = (0x400 << ((w51eRead(W5100_REG_TMSR) & (0x3 << (socket * 2))) >> (socket * 2))) - 1;
+	uint16_t mask = ethSockGetMemSize(socket, W5100_REG_TMSR) - 1;
+	uint16_t baseAddr = ethSockGetMemBaseAddr(socket, W5100_REG_TMSR);
 
 	// Cyclic write single byte until all data is processed or buffer limit is reached
 	uint_fast16_t dataCounter = 0;
 	while ((dataCounter < dataLength) && (dataCounter < freeSize))
 	{
-		//w51eWrite(W5100_CHIP_BASE + W5100_TXM_BASE + (((writeStart + dataCounter) % (mask + 1)) & mask), dataBuffer[dataCounter]);
-		w51eWrite(W5100_CHIP_BASE + W5100_TXM_BASE + ((writeStart + dataCounter) & mask), dataBuffer[dataCounter]);
+		w51eWrite(baseAddr + ((writeStart + dataCounter) & mask), dataBuffer[dataCounter]);
 		++dataCounter;
 	}
 
@@ -259,5 +454,113 @@ uint16_t ethWrite(socket_t socket, uint8_t* dataBuffer, uint16_t dataLength)
 	// Trigger sending data till new TXR address
 	w51eWrite(W5100_SRG(socket, W5100_REG_S0_CR), W5100_Sn_CR_SEND);
 
+	// Wait until data is sent
+	uint_fast16_t timeout = 0;
+	while (!(w51eRead(W5100_SRG(socket, W5100_REG_S0_IR)) & W5100_Sn_IR_SEND_OK) && (timeout < UINT_FAST16_MAX)) 
+	{
+		++timeout;
+	}
+	if (timeout == UINT_FAST16_MAX)
+	{
+		// Timeout error
+		ERROR_LOG("Timeout sending data");
+		return 0;
+	}
+
 	return dataCounter;
+}
+
+/*!	@brief Write data to non-TCP/IP socket for transmission
+ *
+ *	@param[in] socket		Socket to send from
+ *	@param[in] *targetPeer	Target IP+port
+ *	@param[in] *dataBuffer	Source data buffer
+ *	@param[in] dataLength	Number of bytes to send from buffer
+ *	@return int				Actual number of bytes sent
+ *	@date 23.04.17			First implementation					*/
+int ethWriteTo(socket_t socket, peer_t* targetPeer, uint8_t* dataBuffer, int dataLength)
+{
+	// Abort if no data to be written
+	if (dataLength == 0)
+	{
+		return 0;
+	}
+
+	// Set destination IP address
+	w51eWrite(W5100_SRG(socket, W5100_REG_S0_DIPR0), targetPeer->ip[0]);
+	w51eWrite(W5100_SRG(socket, W5100_REG_S0_DIPR1), targetPeer->ip[1]);
+	w51eWrite(W5100_SRG(socket, W5100_REG_S0_DIPR2), targetPeer->ip[2]);
+	w51eWrite(W5100_SRG(socket, W5100_REG_S0_DIPR3), targetPeer->ip[3]);
+
+	// Set destination port
+	w51eWriteW(W5100_SRG(socket, W5100_REG_S0_DPORT0), targetPeer->port);
+
+	// Abort if device transmit memory is full
+	int freeSize = w51eReadW(W5100_SRG(socket, W5100_REG_S0_TX_FSR0));
+	if (freeSize == 0)
+	{
+		ERROR_LOG("TXM full");
+		return 0;
+	}
+
+	// Get send pointer and mask from device
+	uint16_t writeStart = w51eReadW(W5100_SRG(socket, W5100_REG_S0_TX_WR0));
+	uint16_t mask = ethSockGetMemSize(socket, W5100_REG_TMSR) - 1;
+	uint16_t baseAddr = ethSockGetMemBaseAddr(socket, W5100_REG_TMSR);
+
+	// Cyclic write single byte until all data is processed or buffer limit is reached
+	uint_fast16_t dataCounter = 0;
+	while ((dataCounter < dataLength) && (dataCounter < freeSize))
+	{
+		w51eWrite(baseAddr + ((writeStart + dataCounter) & mask), dataBuffer[dataCounter]);
+		++dataCounter;
+	}
+	
+	// Set up write pointer for next transmit operation
+	w51eWriteW(W5100_SRG(socket, W5100_REG_S0_TX_WR0), (writeStart + dataCounter));
+
+	// Handle hardware bug where the NIC would send an 
+	// invalid ARP reply if the target's IP address is
+	// "0.0.0.0".
+	// See Erratasheet p.9 (Erratum 2)
+	if ((targetPeer->ip[0] == 0) && (targetPeer->ip[1] == 0) && (targetPeer->ip[2] == 0) && (targetPeer->ip[3] == 0))
+	{
+		w51eWrite(W5100_REG_SUBR0, 0x00);
+		w51eWrite(W5100_REG_SUBR1, 0x00);
+		w51eWrite(W5100_REG_SUBR2, 0x00);
+		w51eWrite(W5100_REG_SUBR3, 0x00);
+	}
+
+	// Trigger sending data till new TXR address
+	w51eWrite(W5100_SRG(socket, W5100_REG_S0_CR), W5100_Sn_CR_SEND);
+
+	// Wait until data is sent
+	uint_fast16_t timeout = 0;
+	while (!(w51eRead(W5100_SRG(socket, W5100_REG_S0_IR)) & W5100_Sn_IR_SEND_OK) && (timeout < UINT_FAST16_MAX))
+	{
+		++timeout;
+	}
+	if (timeout == UINT_FAST16_MAX)
+	{
+		// A timeout may be caused by a hardware bug where
+		// TX_RD and TX_WR will never equal. Socket must be
+		// reset in this case
+		
+		// Timeout error
+		ERROR_LOG("Timeout sending data");
+		ethSockClose(socket);
+		return 0;
+	}
+
+	// Re-apply previous Subnet mask, if it was
+	// reset to handle hardware bug (see above).
+	if ((targetPeer->ip[0] == 0) && (targetPeer->ip[1] == 0) && (targetPeer->ip[2] == 0) && (targetPeer->ip[3] == 0))
+	{
+		w51eWrite(W5100_REG_SUBR0, ethSubnetBackup[0]);
+		w51eWrite(W5100_REG_SUBR1, ethSubnetBackup[1]);
+		w51eWrite(W5100_REG_SUBR2, ethSubnetBackup[2]);
+		w51eWrite(W5100_REG_SUBR3, ethSubnetBackup[3]);
+	}
+
+	return dataLength;
 }

--- a/core/Ethernet/Ethernet.h
+++ b/core/Ethernet/Ethernet.h
@@ -1,31 +1,41 @@
-/*
- * Ethernet.h
+/*! @brief Data exchange over Ethernet
  *
- * Created: 12/11/2016 3:21:41 AM
- *  Author: inselc
- */ 
+ *	@author inselc
+ *	@date 13.12.16			Initial version
+ *	@date 10.04.17			Added socket ops, tcp r/w				
+ *	@date 18.04.17			Added udp, ipraw r/w
+ *	@date 23.04.17			Changed uint16 to bool/int
+ *	@date 23.04.17			Added peer_t type						*/
 
 #ifndef ETHERNET_H_
 #define ETHERNET_H_
 
+/*! @file */
+
 #include <stdint.h>
+#include <stdbool.h>
 
 typedef uint8_t socket_t;
 
-void ethInit(void);
+typedef struct {
+	uint8_t ip[4];
+	uint16_t port;
+} peer_t;
+
+void ethInit(uint8_t txMemSizes, uint8_t rxMemSizes);
 void ethSetLocalIP(uint8_t mac[6], uint8_t subnet[4], uint8_t ip[4]);
 
-uint8_t ethSockOpen(socket_t socket, uint16_t port, uint8_t protocol, uint8_t modeFlags);
+bool ethSockOpen(socket_t socket, uint16_t port, uint8_t protocol, uint8_t modeFlags);
 void ethSockClose(socket_t socket);
 
-uint8_t ethSockListen(socket_t socket);
-uint8_t ethSockConnect(socket_t socket, uint8_t host, uint8_t port);
+bool ethSockListen(socket_t socket);
+bool ethSockConnect(socket_t socket, peer_t* targetPeer);
 void ethSockDisconnect(socket_t socket);
 
-uint16_t ethAvailable(socket_t socket);
-uint16_t ethRead(socket_t socket, uint8_t* dataBuffer, uint16_t bufSize);
-uint16_t ethReadFrom(socket_t socket, uint8_t srcIP[4], uint16_t port, uint8_t* dataBuffer, uint16_t bufSize);
-uint16_t ethWrite(socket_t socket, uint8_t* dataBuffer, uint16_t dataLength);
-uint16_t ethWriteTo(socket_t socket, uint8_t destIP[4], uint16_t port, uint8_t* dataBuffer, uint16_t dataLength);
+int ethAvailable(socket_t socket);
+int ethRead(socket_t socket, uint8_t* dataBuffer, int bufSize);
+int ethReadFrom(socket_t socket, peer_t* sourcePeer, uint8_t* dataBuffer, int bufSize);
+int ethWrite(socket_t socket, uint8_t* dataBuffer, int dataLength);
+int ethWriteTo(socket_t socket, peer_t* targetPeer, uint8_t* dataBuffer, int dataLength);
 
 #endif /* ETHERNET_H_ */

--- a/core/Serial/Serial.c
+++ b/core/Serial/Serial.c
@@ -217,6 +217,30 @@ int serialWriteStr(const char* message)
 	return stringPos;
 }
 
+/*! @brief Output flash string via serial connection (USART RS232)
+ *
+ * This method will only work, if USART is configured for a
+ * character length of 8+ bits!
+ *
+ *	@param[in] *message			Message in PROGMEM
+ *	@return int					Number of characters sent
+ *	@date 22.12.16				first implementation				*/
+int serialWriteStrP(PGM_P message) 
+{
+	int stringPos = 0;
+	char msgChar = (char)pgm_read_byte(message);
+
+	while ((msgChar != '\0') && (stringPos < SERIAL_MAX_STRLEN))
+	{
+		usartWaitDREmpty();
+		usartSendData(msgChar);
+		stringPos++;
+		msgChar = (char)pgm_read_byte(message+stringPos);
+	}
+
+	return stringPos;
+}
+
 /*! @brief Output via serial from non-progmem memory buffer
  *
  * This method will ignore the buffer content, and output until

--- a/core/Serial/Serial.h
+++ b/core/Serial/Serial.h
@@ -49,6 +49,7 @@ uint8_t serialReadBufUntil(uint8_t* buffer, uint8_t bufSize, char stopChar, int 
 uint8_t serialRead(void);
 uint8_t serialPeek(void);
 int serialWriteStr(const char* message);
+int serialWriteStrP(PGM_P message);
 uint16_t serialWriteBuf(uint8_t* data, uint16_t length, int timeout);
 void serialFlush(void);
 

--- a/core/Watchdog/Watchdog.c
+++ b/core/Watchdog/Watchdog.c
@@ -26,14 +26,15 @@ static bool gracefulReset;
  *	@note The watchdog needs to be reset ("petted") every 120ms,
  *		  or the system will be reset with an error
  *
- *	@date 15.04.17			First implementation					*/
+ *	@date 15.04.17			First implementation
+ *	@date 23.04.17			Adjusted timeout time					*/
 void wdogInit(void)
 {
 	// Default to error-reset
 	gracefulReset = false;
 	
 	cli();
-	wdt_enable(WDTO_500MS);
+	wdt_enable(WDTO_2S);
 
 	// Interrupt+System Reset Mode
 	WDTCSR |= (1 << WDE) | (1 << WDIE);
@@ -66,12 +67,12 @@ ISR(WDT_vect)
 	cli();
 	if (gracefulReset)
 	{
-		serialWriteStr("Rebooting...\r\n\r\n");
+		serialWriteStrP(PSTR("Rebooting...\r\n\r\n"));
 		; // Save stuff
 	}
 	else
 	{
-		serialWriteStr("Error: Watchdog timeout.\r\n\r\n");
+		serialWriteStrP(PSTR("Error: Watchdog timeout.\r\n\r\n"));
 		; // Display error message
 	}
 

--- a/drivers/W5100/W5100.c
+++ b/drivers/W5100/W5100.c
@@ -24,10 +24,10 @@ static pin_t csPinW5100 = {
 void w51eInit(void)
 {
 	// Set up GPIO
-	ioInitPin(csPinW5100);
+	ioInitPin(&csPinW5100);
 
 	// Default CS disabled
-	ioWritePin(csPinW5100, HIGH);
+	ioWritePin(&csPinW5100, HIGH);
 }
 
 /*!	@brief Write data to W5100 register
@@ -38,31 +38,31 @@ void w51eInit(void)
 void w51eWrite(w51eReg_t reg, uint8_t data)
 {
 	// Enable ChipSelect
-	ioWritePin(csPinW5100, LOW);
+	ioWritePin(&csPinW5100, LOW);
 
 	if (spiTransfer(0xF0) != 0x00)	// "Read" opcode
 	{
-		ioWritePin(csPinW5100, HIGH);
+		ioWritePin(&csPinW5100, HIGH);
 		return;
 	}
 	if (spiTransfer(reg >> 8) != 0x01)	// Address high byte
 	{
-		ioWritePin(csPinW5100, HIGH);
+		ioWritePin(&csPinW5100, HIGH);
 		return;
 	}
 	if(spiTransfer(reg) != 0x02) // Address low byte
 	{
-		ioWritePin(csPinW5100, HIGH);
+		ioWritePin(&csPinW5100, HIGH);
 		return;
 	}
 	if(spiTransfer(data) != 0x03)
 	{
-		ioWritePin(csPinW5100, HIGH);
+		ioWritePin(&csPinW5100, HIGH);
 		return;
 	}
 
 	// Disable ChipSelect
-	ioWritePin(csPinW5100, HIGH);
+	ioWritePin(&csPinW5100, HIGH);
 }
 
 /*! @brief Read data from W5100 register
@@ -74,29 +74,29 @@ uint8_t w51eRead(w51eReg_t reg)
 	uint8_t c;
 
 	// Enable ChipSelect
-	ioWritePin(csPinW5100, LOW);
+	ioWritePin(&csPinW5100, LOW);
 
 	// Transmit frame and read data
 	if (spiTransfer(0x0F) != 0x00)	// "Read" opcode
 	{
-		ioWritePin(csPinW5100, HIGH);
+		ioWritePin(&csPinW5100, HIGH);
 		return 0x00;
 	}
 	if (spiTransfer(reg >> 8) != 0x01)	// Address high byte
 	{
-		ioWritePin(csPinW5100, HIGH);
+		ioWritePin(&csPinW5100, HIGH);
 		return 0x00;
 	}
 	if(spiTransfer(reg & 0x00FF) != 0x02) // Address low byte
 	{
-		ioWritePin(csPinW5100, HIGH);
+		ioWritePin(&csPinW5100, HIGH);
 		return 0x00;
 	}
 	c = spiTransfer(0xFF);
 
 
 	// Disable ChipSelect
-	ioWritePin(csPinW5100, HIGH);
+	ioWritePin(&csPinW5100, HIGH);
 
 	return c;
 }

--- a/modules/io/io.h
+++ b/modules/io/io.h
@@ -1,7 +1,8 @@
 /*! @brief I/O definitions
  *
  *	@author	inselc
- *	@date	04.12.16	initial version								*/
+ *	@date	04.12.16	initial version
+ *	@date	23.04.17	Fixed pin_t pointers						*/
 
 #ifndef IO_H_
 #define IO_H_
@@ -71,34 +72,37 @@ static inline void ioSetPinDirection(pin_t* pin, pinDir_t direction)
 
 /*! @brief Read the digital pin state
  *
- *  @param[in] pin			Selected pin
+ *  @param[in] *pin			Selected pin
  *	@return bool			Pin state
- *  @date 04.12.16			first implementation					*/
-static inline bool ioReadPin(pin_t pin)
+ *  @date 04.12.16			first implementation
+ *	@date 23.04.17			Fixed pin_t pointer type				*/
+static inline bool ioReadPin(pin_t* pin)
 {
 	// return pin state as boolean
-	return (bool)(*pin.Port & (1 << pin.Number));
+	return (bool)(*pin->Port & (1 << pin->Number));
 }
 
 /*! @brief Set the digital pin state
  * 
- *	@param[in] pin			Target pin
+ *	@param[in] *pin			Target pin
  *	@param[in] state		Output state
- *	@date 04.12.16			first implementation					*/
-static inline void ioWritePin(pin_t pin, bool state)
+ *	@date 04.12.16			first implementation
+ *	@date 23.04.17			Fixed pin_t pointer type				*/
+static inline void ioWritePin(pin_t* pin, bool state)
 {
 	// apply new state to pin output
-	*pin.Port &= ~(!state << pin.Number);
-	*pin.Port |= state << pin.Number;
+	*pin->Port &= ~(!state << pin->Number);
+	*pin->Port |= state << pin->Number;
 }
 
 /*! @brief Configure Pull-ups for I/O pin
  *
  *	@warning Pin must be set into safe configuration for transition beforehand!
  * 
- *	@param[inout] pin		Selected pin configuration
+ *	@param[inout] *pin		Selected pin configuration
  *	@param[in] pullUpEnable	New pullup-disable state
- *	@data 04.12.16			first implementation					*/
+ *	@data 04.12.16			first implementation
+ *	@date 23.04.17			Fixed pin_t pointer type				*/
 static inline void ioSetPinPullup(pin_t* pin, bool pullUpEnable)
 {
 	// apply pull-up only, if pin direction is an output.
@@ -109,7 +113,7 @@ static inline void ioSetPinPullup(pin_t* pin, bool pullUpEnable)
 
 		// Apply pull-up configuration as per
 		// datasheet p. 99 (18.2.3 Switching Between Input and Output)
-		ioWritePin(*pin, pin->PullUp);
+		ioWritePin(pin, pin->PullUp);
 	}
 }
 
@@ -117,14 +121,15 @@ static inline void ioSetPinPullup(pin_t* pin, bool pullUpEnable)
  *
  *	@note Outputs will be initialised with a default LOW state.
  *
- *	@param[in] pinConf		Pin configuration
- *	@date 04.12.16			first implementation					*/
-static inline void ioInitPin(pin_t pinConf)
+ *	@param[in] *pinConf		Pin configuration
+ *	@date 04.12.16			first implementation
+ *	@date 23.04.17			Fixed pin_t pointer type				*/
+static inline void ioInitPin(pin_t* pinConf)
 {
 	// Set pin direction in DDR
-	ioSetPinDirection(&pinConf, pinConf.Direction);
+	ioSetPinDirection(pinConf, pinConf->Direction);
 	// Set pull-up configuration, if pin is an input
-	ioSetPinPullup(&pinConf, pinConf.PullUp);
+	ioSetPinPullup(pinConf, pinConf->PullUp);
 }
 
 /*! @brief Globally disable pull-up resistors via the MCUCR PUD bit.
@@ -141,15 +146,16 @@ static inline void ioSetGlobalPullUp(bool PUDisable)
  *
  *  @note Pin must be configured as an output!
  * 
- *	@param[in] pin			Target pin
- *	@date 04.12.16			first implementation					*/
-static inline void ioTogglePin(pin_t pin)
+ *	@param[in] *pin			Target pin
+ *	@date 04.12.16			first implementation
+ *	@date 23.04.17			Fixed pin_t pointer type				*/
+static inline void ioTogglePin(pin_t* pin)
 {
 	//if ( (*pin.DDR & (1 << pin.Number)) && (pin.Direction == OUTPUT) )
 	{
 		// The PIN register is a W1T-type register as per
 		// datasheet p. 99 (18.2.2 Toggling the Pin)
-		*pin.PINR = 1 << pin.Number;
+		*pin->PINR = 1 << pin->Number;
 	}
 }
 

--- a/modules/spi/spi_master.h
+++ b/modules/spi/spi_master.h
@@ -1,7 +1,8 @@
 /*! @brief SPI Master-mode definitions
  *
  *	@author	inselc
- *	@date	05.12.16	initial version								*/ 
+ *	@date	05.12.16	initial version	
+ *	@date	23.04.17	Added getSpiClkRate							*/ 
 
 #ifndef SPI_MASTER_H_
 #define SPI_MASTER_H_
@@ -36,6 +37,18 @@ static inline void spiSetMstrClkRate(spiClkRate_t rate)
 	// SPI Clock Rate Select
 	SPCR &= ~(((~rate)&0x03) << SPR0);
 	SPCR |= (rate&0x03) << SPR0;
+}
+
+/*!	@brief Get current SPI Clock rate configuration 
+ *
+ *	@return spiClkRate_t	SPI Clock rate
+ *	@date 23.04.17			First implementation					*/
+static inline spiClkRate_t spiGetMstrClkRate(void)
+{
+	spiClkRate_t rate = (SPCR >> SPR0) & 0x03;
+	rate |= ((SPSR >> SPI2X) & 0x01) << 2;
+
+	return rate;
 }
 
 void spiInitMaster(spiClkRate_t clkRate, spiClkMode_t clkMode, spiDataOrder_t dataOrder);


### PR DESCRIPTION
This PR adds UDP and TCP client mode to the Ethernet core functions, fixes GPIO methods using call-by-value, moves most of the string literals from RAM to flash program memory, increases the Watchdog timer timeout time to 2 seconds, and adds an SPI Master module method to read the current clock rate configuration.

## Socket I/O, Part 2
Sockets can now be operated in TCP client mode or UDP mode. The `ethInit` proc has been extended to allow individual memory size configuration for each socket.

### TCP client mode
To connect to a server via TCP/IP as a client, use the `ethSockConnect` method after opening the socket to initiate the connection. If this step fails, it will return `false`.
To transfer data, use the `ethRead` and `ethWrite` functions.

### UDP mode
UDP does not use connect-sequences to establish a connection between two peers. Data gets transferred directly. 
To receive UDP data, use the `ethReadFrom` function. This will return the peer IP and port in the targetPeer struct.
To send UDP data, use the `ethWriteTo` function, and pass it the target peer's IP address and port number in the targetPeer struct.

## String literals
String literals should be stored in flash memory, to save RAM space. Duplicate strings should be stored in a string table, to save flash memory space.
In order to save a string literal in flash memory, use the `PSTR` macro from the AVR-LibC library.
To read data from flash memory, use AVR-LibC functions.

## SPI Master, Part 2
SPI Master mode was extended with a function to read the current SPI Master clock rate configuration. This can be used when temporarily changing the SPI clock speed, e.g. for SD card initialisation.