### PR TITLE
Adds Timer0 controls, Dimmer controller via GPIO

### DIFF
--- a/core/Dimmer/Dimmer.c
+++ b/core/Dimmer/Dimmer.c
@@ -1,0 +1,79 @@
+/*!	@brief Dimmer functionality using bit angle modulation, control-
+ *	              ling pins directly connected to the MCU.
+ *
+ *	This dimmer module uses Timer 0 and Output Compare module A 
+ *	to modulate the output signals.
+ *
+ *	@author inselc
+ *	@date 28.04.17			First implementation					*/
+
+#include <stdio.h>
+#include <avr/interrupt.h>
+#include "../../modules/timer/timer.h"
+#include "Dimmer.h"
+
+/*!	@brief Precalculated Output Compare Register values for
+ *	       bit angle modulation										*/
+static const uint8_t dimmerBitAngleTimings[8] = {
+	0x01,
+	0x03,
+	0x07,
+	0x0F,
+	0x1F,
+	0x3F,
+	0x7F,
+	0xFF
+};
+volatile static uint8_t dimmerCurrentBit = 0;				//!< Currently displayed bit
+static pin_t** dimmerOutputs = NULL;						//!< Array of output pin descriptions
+static uint8_t* dimmerValues;								//!< Corresponding channel values
+static uint8_t dimmerOutputsCount = 0;						//!< Number of channels
+
+/*!	@brief Initialise the Dimmer module
+ *
+ *	@param[in] **outputs	Output Pin definitions
+ *	@param[in] *values		Channel values
+ *	@param[in] outputCount	Number of channels
+ *	@date 28.04.17			First implementation					*/
+void dimmerInit(pin_t** outputs, uint8_t* values, int outputCount)
+{
+	// Stop any running timer0
+	timer0Stop();
+	
+	// Setup pointers
+	dimmerOutputs = outputs;
+	dimmerOutputsCount = outputCount;
+	dimmerValues = values;
+	dimmerCurrentBit = 0;
+
+	// Initialise Timer 0
+	timer0Init();
+
+	// Setup bit timing for Bit 0
+	timer0SetCompareA(dimmerBitAngleTimings[0]);
+
+	// Enable Timer 0 Compare A interrupt
+	TIMSK0 |= 1 << OCF0A;
+
+	// Start Timer:
+	// 256 prescale, Clear timer on OCRA match
+	timer0Start(TMR0_CLK_PRESC_DIV_256, TMR0_WG_CTC);
+}
+
+// -----------------------------------------------------------------
+
+/*!	@brief Timer 0 Compare Match ISR: bit angle modulation
+ *
+ *	@date 28.04.17		First implementation						*/
+ISR(TIMER0_COMPA_vect)
+{
+	for (uint_fast8_t i = 0; i < dimmerOutputsCount; ++i)
+	{
+		ioWritePin(dimmerOutputs[i], dimmerValues[i] & (1 << (dimmerCurrentBit)));
+	}
+	timer0SetCompareA(dimmerBitAngleTimings[dimmerCurrentBit]);
+	
+	// Cycle through bits
+	++dimmerCurrentBit;
+	dimmerCurrentBit %= 8;
+}

--- a/core/Dimmer/Dimmer.h
+++ b/core/Dimmer/Dimmer.h
@@ -1,0 +1,17 @@
+/*!	@brief Dimmer functionality using bit angle modulation, control-
+ *	              ling pins directly connected to the MCU.
+ *
+ *	@author inselc
+ *	@date 28.04.17			First implementation					*/
+
+#ifndef DIMMER_H_
+#define DIMMER_H_
+
+/*!	@file */
+
+#include <stdint.h>
+#include "../../modules/io/io.h"
+
+void dimmerInit(pin_t** outputs, uint8_t* values, int outputCount);
+
+#endif /* DIMMER_H_ */

--- a/modules/timer/timer.h
+++ b/modules/timer/timer.h
@@ -1,0 +1,15 @@
+/*!	@brief Common timer definitions include file
+ *
+ *	This will include all available timer modules
+ *
+ *	@author inselc
+ *	@date 28.04.17		First implementation						*/
+
+#ifndef TIMER_H_
+#define TIMER_H_
+
+/*!	@file */
+
+#include "timer0.h"
+
+#endif /* TIMER_H_ */

--- a/modules/timer/timer0.h
+++ b/modules/timer/timer0.h
@@ -1,0 +1,131 @@
+/*!	@brief Timer 0 Definitions
+ *
+ *	@author inselc
+ *	@date 28.04.17		First implementation						*/
+
+#ifndef TIMER0_H_
+#define TIMER0_H_
+
+/*!	@file */
+
+typedef enum {
+	TMR0_CLK_OFF = 0x00,			//!< Clock off
+	TMR0_CLK_PRESC_DIV_1 = 0x01,	//!< T = T_io
+	TMR0_CLK_PRESC_DIV_8 = 0x02,	//!< T = T_io / 8
+	TMR0_CLK_PRESC_DIV_64 = 0x03,	//!< T = T_io / 64
+	TMR0_CLK_PRESC_DIV_256 = 0x04,	//!< T = T_io / 256
+	TMR0_CLK_PRESC_DIV_1024 = 0x05,	//!< T = T_io / 1024
+	TMR0_CLK_EXT_FALLING = 0x06,	//!< Ext. clock on T0, falling edge trigger
+	TMR0_CLK_EXT_RISING = 0x07		//!< Ext. clock on T0, rising edge trigger
+} timer0ClkSrc_t;
+
+typedef enum {
+	TMR0_WG_NORMAL = 0x00,			//!< Normal mode
+	TMR0_WG_PCPWM = 0x01,			//!< Phase-correct PWM
+	TMR0_WG_CTC = 0x02,				//!< Clear Timer on Compare Match
+	TMR0_WG_FASTPWM = 0x03,			//!< Fast PWM
+	TMR0_WG_PCPWM_C = 0x05,			//!< Phase-correct PWM with match at OCRA
+	TMR0_WG_FASTPWM_C = 0x07		//!< Fast PWM with match at OCRA
+} timer0WgMode_t;
+
+/*!	@brief Enable Timer0 power
+ *
+ *	@date 28.04.17		First implementation						*/
+static inline void timer0PowerEnable()
+{
+	PRR &= ~(1 << PRTIM0);
+}
+
+/*!	@brief Disable Timer0 power										
+ *
+ *	@date 28.04.17		First implementation						*/
+static inline void timer0PowerDisable(void)
+{
+	PRR |= 1 << PRTIM0;
+}
+
+/*!	@brief Stop Timer0
+ *
+ *	@date 28.04.17		First implementation						*/
+static inline void timer0Stop(void)
+{
+	// Clear Clock source configuration bits
+	TCCR0B &= ~(0x07);
+}
+
+/*! @brief Set Timer0 clock source
+ *
+ *	@param[in] src		Clock/Prescaler configuration
+ *	@date 28.04.17		First implementation						*/
+static inline void timer0SetClkSrc(timer0ClkSrc_t src)
+{
+	// Clear current configuration
+	timer0Stop();
+
+	// Apply clock source configuration
+	TCCR0B |= src & 0x07;
+}
+
+/*!	@brief Set Timer0 Waveform Generator mode
+ *
+ *	@param[in] mode		Waveform Generator mode
+ *	@date 28.04.17		First implementation						*/
+static inline void timer0SetWaveGenMode(timer0WgMode_t genMode)
+{
+	// Clear WGM2:0 bits
+	TCCR0A &= ~(0x03);
+	TCCR0B &= ~(1 << 3);
+
+	// Apply new configuration
+	TCCR0A |= genMode & 0x03;
+	TCCR0B |= (genMode & 0x04) << 1;
+}
+
+/*!	@brief Set Timer0 Compare Register Value
+ *
+ *	@param[in] value	Compare match value
+ *	@date 28.04.17		First implementation						*/
+static inline void timer0SetCompareA(uint_fast8_t value)
+{
+	OCR0A = value;
+}
+static inline void timer0SetCompareB(uint_fast8_t value)
+{
+	OCR0B = value;
+}
+
+/*!	@brief Initialise Timer0
+ *
+ *	@date 29.04.17		Extracted from timer0Start					*/
+static inline void timer0Init(void)
+{
+	// Enable power to the timer module
+	timer0PowerEnable();
+
+	// Stop any running timers
+	timer0Stop();
+
+	// Clear Timer0 interrupt mask
+	TIMSK0 = 0;
+
+	// Clear old Timer0 interrupts
+	// TIFR is a w1r Register as per
+	// datasheet p. 148 (19.9.8 TC0 Interrupt flag register)
+	TIFR0 = 0x03;
+}
+
+/*!	@brief Start Timer0
+ *
+ *	@param[in] clkSrc	Clock source
+ *	@param[in] genMode	Waveform Generator mode
+ *	@date 28.04.17		First implementation						*/
+static inline void timer0Start(timer0ClkSrc_t clkSrc, timer0WgMode_t genMode)
+{
+	// Configure clock source
+	timer0SetClkSrc(clkSrc);
+	
+	// Configure waveform generator mode
+	timer0SetWaveGenMode(genMode);
+}
+
+#endif // TIMER0_H_


### PR DESCRIPTION
This PR adds configuration methods for Timer0, and a basic dimmer controller to control LED drivers via GPIO pins.

## Timer0
Some of the initialisation and control procedures have been aggregated into simple methods.

### Init
The `timer0Init` method will take care of enabling power to the timer module and setting up Timer0 in a stopped state.

### Start/Stop
To start Timer0, use `timer0Start`, passing a clock prescaler value and a waveform generation mode.
To stop Timer0, use `timer0Stop`.

## Dimmer
The dimmer controller will use Timer0 to control the brightness of LEDs connected to GPIO pins, by using bit angle modulation.

### Init
1. Configure all LED output pins and store pointers to the pin_t structs in a globally accessible array.
2. Set up a byte array to contain the "brightness" value for each output pin.
3. Call `dimmerInit` and pass it both arrays, as well as the number of configured output pins.
This will automatically start the timer.